### PR TITLE
Update sqlalchemy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.11"
 rich = "^13.3.4"
-sqlalchemy = "2.0.23"
+sqlalchemy = "2.0.40"
 gitpython = "3.1.41"
 click = "^8.1.3"
 pydantic = "^2.8.2"


### PR DESCRIPTION
SQLAlchemy hit a bug, which the new version has fixed

...

`AssertionError: Class <class 'sqlalchemy.sql.elements.SQLCoreOperations'> directly inherits TypingOnly but has additional attributes {'__static_attributes__', '__firstlineno__'}.`