### PR TITLE
Make pip installable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "bucket"
 version = "2.1.3"
-description = "Functional coverage written in python"
+description = "Functional coverage written in Python"
 authors = [
     "Stuart Alldred <stuartalldred@gmail.com>",
     "Edward Kotarski <edktrsk@gmail.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,19 +4,13 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "bucket"
-<<<<<<< HEAD
 version = "2.1.3"
 description = "Functional coverage written in python"
-=======
-version = "2.1.2"
-description = "Python functional coverage"
->>>>>>> main
 authors = [
     "Stuart Alldred <stuartalldred@gmail.com>",
     "Edward Kotarski <edktrsk@gmail.com>",
 ]
 license = "MIT"
-license-files = ["LICEN[CS]E*"]
 readme = "README.md"
 packages = [
     { include = "bucket" }
@@ -26,8 +20,6 @@ include = [
     "viewer/**/*"
 ]
 
-[project.urls]
-Homepage = "https://github.com/Noodle-Bytes/bucket"
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,28 @@
 [build-system]
-requires = ["poetry"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "bucket"
-version = "0.1"
-description = "Python functional coverage"
+version = "2.1.3"
+description = "Functional coverage written in python"
 authors = [
     "Stuart Alldred <stuartalldred@gmail.com>",
     "Edward Kotarski <edktrsk@gmail.com>",
 ]
 license = "MIT"
+license-files = ["LICEN[CS]E*"]
 readme = "README.md"
+packages = [
+    { include = "bucket" }
+]
+# Include the web viewer assets in the final wheel/sdist
+include = [
+    "viewer/**/*"
+]
+
+[project.urls]
+Homepage = "https://github.com/Noodle-Bytes/bucket"
 
 [tool.poetry.dependencies]
 python = "^3.11"
@@ -25,3 +36,6 @@ pydantic = "^2.8.2"
 pre-commit = "^3.8.0"
 pytest = "^8.0.1"
 pytest-cov = "^4.1.0"
+
+[tool.poetry.scripts]
+bucket = "bucket.__main__:cli"


### PR DESCRIPTION
`poetry build`

  ```
pip3 install twine wheel  # if you don’t have these yet
  twine check dist/*.whl
  unzip -l dist/bucket-*.whl | grep viewer | head
```
  ```
pip install --force-reinstall dist/bucket-*.whl
  bucket --help
```

Not yet run....
`poetry publish --build`
