### PR TITLE
[None] Add RISC-V stress example for large-tree sampling and merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ electron/node_modules/
 
 # Example coverage files (do not check in)
 example*.bktgz
+
+# Stress example local output
+/output/

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved

--- a/examples/riscv_stress/README.md
+++ b/examples/riscv_stress/README.md
@@ -1,0 +1,105 @@
+<!--
+  ~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+  -->
+
+# RISC-V stress example
+
+This example builds a large, nested coverage tree and uses it in two ways:
+
+1. **Sampling** — call `Covertop.sample()` on the full tree (and optionally on
+   replicated copies of it) and measure samples per second.
+2. **Merging** — export many compatible records and time
+   `ArchiveAccessor.merge_files()` / `SQLAccessor.merge_files()` /
+   `JSONAccessor.merge_files()`.
+
+The tree has ten RISC-V-themed modules (instruction formats, memory, pipeline,
+exceptions, register file, control flow, arithmetic, logical, system, compare).
+Covergroups override `should_sample()` so unrelated traces skip whole subtrees,
+the same pattern a real testbench would use.
+
+## Commands
+
+From the repo root, inside `./bin/shell`:
+
+```bash
+# Time sampling the full tree (no files written)
+python -m examples.riscv_stress sample
+
+# Larger tree: replicate every module 4 times
+python -m examples.riscv_stress sample --iters 20000 --copies 4
+
+# Sample, export, and merge a handful of real runs
+python -m examples.riscv_stress run --num-tests 10 --formats archive
+
+# Synthesize many compatible records and time merging them
+python -m examples.riscv_stress generate --num-tests 200 --formats archive sql
+```
+
+`--copies N` repeats the ten-module set with unique names, which is the knob
+for “a really large covertree” without editing the modules.
+
+### `sample`
+
+| Flag | Default | Meaning |
+| -- | -- | -- |
+| `--iters` | 50000 | Number of `cvg.sample(trace)` calls to time |
+| `--warmup` | 1000 | Untimed samples first |
+| `--copies` | 1 | Module-set replicas |
+| `--seed` | 42 | Trace generator seed |
+
+Reports tree build time, coverpoint count, bucket count, samples/sec, and
+microseconds per sample.
+
+### `run`
+
+Builds the tree, samples random traces, exports each test, then merges.
+
+| Flag | Default | Meaning |
+| -- | -- | -- |
+| `--num-tests` | 10 | Independent runs to sample and export |
+| `--samples-per-test` | random 100–500 | Traces per run |
+| `--formats` | `archive sql` | `archive`, `sql`, `json`, `all`, or `both` |
+| `--copies` | 1 | Module-set replicas |
+| `--output-dir` | `./output` | Parent of `riscv_stress/` |
+
+### `generate`
+
+Captures the definition from one real tree, then writes synthetic hit data
+with the same `def_sha` / `rec_sha` so merge stays legal. Use this when you
+want merge-at-scale without waiting on sampling.
+
+| Flag | Default | Meaning |
+| -- | -- | -- |
+| `--num-tests` | 100 | Synthetic records to write |
+| `--hit-rate` | 0.35 | Fraction of buckets given a non-zero count |
+| `--formats` | `archive sql json` | Same as `run` |
+| `--skip-generation` | off | Merge files that are already on disk |
+| `--skip-merge` | off | Write files only |
+
+## Output
+
+```
+output/riscv_stress/
+  test_outputs/
+    archive/test_000.bktgz
+    sql/test_000.db
+    json/test_000.json
+  riscv_stress_merged.bktgz
+  riscv_stress_merged.db
+  riscv_stress_merged.json
+```
+
+Open a merged `.bktgz` in the Bucket viewer.
+
+## Python API
+
+```python
+from pathlib import Path
+from examples.riscv_stress.stress_example import bench_sample, run
+from examples.riscv_stress.generate_stress_data import generate
+
+bench_sample(iters=20_000, copies=2)
+run(output_dir=Path("output"), num_tests=5, export_formats=["archive"])
+generate(output_dir=Path("output"), num_tests=50, formats=["archive"])
+```

--- a/examples/riscv_stress/__init__.py
+++ b/examples/riscv_stress/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved

--- a/examples/riscv_stress/__main__.py
+++ b/examples/riscv_stress/__main__.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+"""RISC-V stress example: sample large covertrees and merge large datasets."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .generate_stress_data import generate
+from .stress_example import bench_sample, run
+
+
+def _add_common_io_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("output"),
+        help="Directory for generated files (default: ./output)",
+    )
+    parser.add_argument(
+        "--formats",
+        nargs="+",
+        default=None,
+        help="Export formats: archive sql json all both (default depends on command)",
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--copies",
+        type=int,
+        default=1,
+        help="Replicate the module set this many times to enlarge the covertree",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sample_p = sub.add_parser(
+        "sample",
+        help="Benchmark Covertop.sample on the full stress tree (no I/O)",
+    )
+    sample_p.add_argument("--iters", type=int, default=50_000)
+    sample_p.add_argument("--warmup", type=int, default=1_000)
+    sample_p.add_argument("--copies", type=int, default=1)
+    sample_p.add_argument("--seed", type=int, default=42)
+
+    run_p = sub.add_parser(
+        "run",
+        help="Sample, export, and merge real coverage runs",
+    )
+    _add_common_io_args(run_p)
+    run_p.add_argument("--num-tests", type=int, default=10)
+    run_p.add_argument(
+        "--samples-per-test",
+        type=int,
+        default=None,
+        help="Traces per test (default: random 100-500)",
+    )
+
+    gen_p = sub.add_parser(
+        "generate",
+        help="Synthesize many compatible readouts and time merging them",
+    )
+    _add_common_io_args(gen_p)
+    gen_p.add_argument("--num-tests", type=int, default=100)
+    gen_p.add_argument("--skip-generation", action="store_true")
+    gen_p.add_argument("--skip-merge", action="store_true")
+    gen_p.add_argument("--max-hits", type=int, default=1000)
+    gen_p.add_argument(
+        "--hit-rate",
+        type=float,
+        default=0.35,
+        help="Fraction of buckets given a non-zero hit count (default: 0.35)",
+    )
+
+    args = parser.parse_args()
+    if args.command == "sample":
+        bench_sample(
+            iters=args.iters,
+            warmup=args.warmup,
+            copies=args.copies,
+            seed=args.seed,
+        )
+        return 0
+    if args.command == "run":
+        run(
+            output_dir=args.output_dir,
+            num_tests=args.num_tests,
+            seed=args.seed,
+            export_formats=args.formats,
+            samples_per_test=args.samples_per_test,
+            copies=args.copies,
+        )
+        return 0
+    generate(
+        output_dir=args.output_dir,
+        num_tests=args.num_tests,
+        seed=args.seed,
+        formats=args.formats,
+        copies=args.copies,
+        skip_generation=args.skip_generation,
+        skip_merge=args.skip_merge,
+        max_hits=args.max_hits,
+        hit_rate=args.hit_rate,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/riscv_stress/generate_stress_data.py
+++ b/examples/riscv_stress/generate_stress_data.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from __future__ import annotations
+
+import logging
+import random
+from pathlib import Path
+
+from bucket.rw import PointReader
+from bucket.rw.common import (
+    BucketHitTuple,
+    PointHitTuple,
+    PuppetReadout,
+)
+
+from .stress_common import RISCVDataset, build_coverage, context_hash, generate_trace
+from .stress_example import export_readout, merge_format, parse_formats
+
+
+def capture_definition(copies: int = 1, seed: int = 42) -> PuppetReadout:
+    """Build the stress tree once so synthetic records share a definition."""
+    log = logging.getLogger("stress_generate")
+    log.info("Capturing coverage definition from one sampled tree...")
+    riscv_data = RISCVDataset()
+    rand = random.Random(seed)
+    cvg = build_coverage(
+        copies=copies,
+        source="definition_template",
+        source_key="definition",
+        riscv_data=riscv_data,
+    )
+    for _ in range(32):
+        cvg.sample(generate_trace(rand, riscv_data))
+    readout = PointReader(context_hash()).read(cvg)
+    log.info(
+        "Definition captured: %d points, %d buckets",
+        len(list(readout.iter_points())),
+        len(list(readout.iter_bucket_goals())),
+    )
+    return readout
+
+
+def copy_definition(src: PuppetReadout) -> PuppetReadout:
+    dest = PuppetReadout()
+    dest.def_sha = src.get_def_sha()
+    dest.rec_sha = src.get_rec_sha()
+    dest.bucket_version = src.get_bucket_version()
+    dest.format_version = src.get_format_version()
+    dest.points = list(src.iter_points())
+    dest.axes = list(src.iter_axes())
+    dest.axis_values = list(src.iter_axis_values())
+    dest.goals = list(src.iter_goals())
+    dest.bucket_goals = list(src.iter_bucket_goals())
+    return dest
+
+
+def calculate_point_hits(
+    definition: PuppetReadout, bucket_hits: list[int]
+) -> list[PointHitTuple]:
+    goal_targets = [goal.target for goal in definition.goals]
+    bucket_targets = [
+        goal_targets[bucket_goal.goal] for bucket_goal in definition.bucket_goals
+    ]
+    point_hits = []
+    for point in definition.points:
+        hits = 0
+        hit_buckets = 0
+        full_buckets = 0
+        for bucket_idx in range(point.bucket_start, point.bucket_end):
+            bucket_hit_count = bucket_hits[bucket_idx]
+            target = (
+                bucket_targets[bucket_idx] if bucket_idx < len(bucket_targets) else 0
+            )
+            if target > 0:
+                bucket_hits_clamped = min(bucket_hit_count, target)
+                if bucket_hit_count > 0:
+                    hit_buckets += 1
+                    if bucket_hits_clamped == target:
+                        full_buckets += 1
+                    hits += bucket_hits_clamped
+        point_hits.append(
+            PointHitTuple(
+                start=point.start,
+                depth=point.depth,
+                hits=hits,
+                hit_buckets=hit_buckets,
+                full_buckets=full_buckets,
+            )
+        )
+    return point_hits
+
+
+def generate_synthetic_readout(
+    definition: PuppetReadout,
+    test_num: int,
+    rand: random.Random,
+    *,
+    max_hits: int = 1000,
+    hit_rate: float = 0.35,
+) -> PuppetReadout:
+    readout = copy_definition(definition)
+    num_buckets = len(definition.bucket_goals)
+    bucket_hits_list = [
+        rand.randint(1, max_hits) if rand.random() < hit_rate else 0
+        for _ in range(num_buckets)
+    ]
+    readout.bucket_hits = [
+        BucketHitTuple(start=i, hits=hits) for i, hits in enumerate(bucket_hits_list)
+    ]
+    readout.point_hits = calculate_point_hits(definition, bucket_hits_list)
+    readout.source = f"synthetic_test_{test_num:03d}"
+    readout.source_key = str(rand.randint(1, 1_000_000))
+    return readout
+
+
+def generate(
+    output_dir: Path = Path("output"),
+    num_tests: int = 100,
+    seed: int = 42,
+    formats: list[str] | None = None,
+    copies: int = 1,
+    skip_generation: bool = False,
+    skip_merge: bool = False,
+    max_hits: int = 1000,
+    hit_rate: float = 0.35,
+):
+    """Generate synthetic readouts matching the stress tree, then merge them."""
+    logging.basicConfig(level=logging.INFO)
+    log = logging.getLogger("stress_generate")
+    export_formats = parse_formats(formats if formats is not None else ["all"])
+
+    stress_output_dir = output_dir / "riscv_stress"
+    test_outputs_dir = stress_output_dir / "test_outputs"
+    test_outputs_dir.mkdir(parents=True, exist_ok=True)
+
+    if not skip_generation:
+        definition = capture_definition(copies=copies, seed=seed)
+        rand = random.Random(seed)
+        log.info(
+            "Generating %d synthetic readouts (hit_rate=%.2f, copies=%d)",
+            num_tests,
+            hit_rate,
+            copies,
+        )
+        for test_num in range(num_tests):
+            readout = generate_synthetic_readout(
+                definition,
+                test_num,
+                rand,
+                max_hits=max_hits,
+                hit_rate=hit_rate,
+            )
+            export_readout(
+                readout, test_outputs_dir, f"test_{test_num:03d}", export_formats
+            )
+            if (test_num + 1) % 50 == 0 or test_num + 1 == num_tests:
+                log.info("Wrote %d/%d synthetic files", test_num + 1, num_tests)
+
+    if skip_merge:
+        return
+
+    times: dict[str, float] = {}
+    for fmt in export_formats:
+        fmt_dir = test_outputs_dir / fmt
+        if fmt == "archive":
+            paths = sorted(fmt_dir.glob("test_*.bktgz"))
+            merged_path = stress_output_dir / "riscv_stress_merged.bktgz"
+        elif fmt == "sql":
+            paths = sorted(fmt_dir.glob("test_*.db"))
+            merged_path = stress_output_dir / "riscv_stress_merged.db"
+        else:
+            paths = sorted(fmt_dir.glob("test_*.json"))
+            merged_path = stress_output_dir / "riscv_stress_merged.json"
+        if num_tests:
+            paths = paths[:num_tests]
+        times[fmt] = merge_format(log, paths, merged_path, fmt)
+
+    log.info("=" * 60)
+    log.info("Synthetic generation complete")
+    for fmt, elapsed in times.items():
+        log.info("  %s merge: %.2fs", fmt, elapsed)
+    if len(times) >= 2:
+        ordered = sorted(
+            ((fmt, elapsed) for fmt, elapsed in times.items() if elapsed > 0),
+            key=lambda item: item[1],
+        )
+        if len(ordered) >= 2:
+            fastest, slowest = ordered[0], ordered[-1]
+            log.info(
+                "  %s was %.2fx faster than %s",
+                fastest[0],
+                slowest[1] / fastest[1],
+                slowest[0],
+            )
+    log.info("=" * 60)

--- a/examples/riscv_stress/stress_common.py
+++ b/examples/riscv_stress/stress_common.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from __future__ import annotations
+
+import math
+import random
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from bucket import CoverageContext, Coverpoint, Covertop
+
+from .stress_top import StressTop
+
+
+class RISCVDataset:
+    """
+    RISC-V instruction set data for coverage.
+    This provides a rich dataset for generating large coverage trees.
+    """
+
+    instruction_formats = [
+        "R-type",
+        "I-type",
+        "S-type",
+        "B-type",
+        "U-type",
+        "J-type",
+    ]
+
+    opcodes = list(range(0x00, 0x80, 0x04))  # 32 opcodes
+    registers = [f"x{i}" for i in range(32)]
+
+    instruction_categories = [
+        "Arithmetic",
+        "Logical",
+        "Shift",
+        "Compare",
+        "Load",
+        "Store",
+        "Branch",
+        "Jump",
+        "System",
+        "Fence",
+    ]
+
+    instruction_types = [
+        "ADD",
+        "SUB",
+        "AND",
+        "OR",
+        "XOR",
+        "SLT",
+        "SLTU",
+        "SLL",
+        "SRL",
+        "SRA",
+        "BEQ",
+        "BNE",
+        "BLT",
+        "BGE",
+        "BLTU",
+        "BGEU",
+        "JAL",
+        "JALR",
+        "LW",
+        "SW",
+        "LUI",
+        "AUIPC",
+    ]
+
+    memory_patterns = [
+        "sequential",
+        "random",
+        "aligned",
+        "unaligned",
+        "cache_line",
+    ]
+
+    execution_states = [
+        "idle",
+        "fetch",
+        "decode",
+        "execute",
+        "memory",
+        "writeback",
+        "exception",
+    ]
+
+    pipeline_stages = list(range(5))
+    branch_outcomes = ["taken", "not_taken", "mispredicted"]
+    exception_types = [
+        "none",
+        "illegal_instruction",
+        "misaligned_address",
+        "page_fault",
+        "timer_interrupt",
+    ]
+    cache_states = ["hit", "miss", "evict", "writeback"]
+    data_sizes = [8, 16, 32, 64]
+    alignments = [1, 2, 4, 8, 16]
+    privilege_levels = ["user", "supervisor", "machine"]
+    csr_registers = [f"csr_{i:03x}" for i in range(0, 0x100, 0x10)]
+
+
+@dataclass
+class InstructionTrace:
+    """Trace data for a RISC-V instruction execution"""
+
+    opcode: int
+    format_type: str
+    category: str
+    instruction_type: str
+    rd: Optional[str] = None
+    rs1: Optional[str] = None
+    rs2: Optional[str] = None
+    immediate: Optional[int] = None
+    execution_state: Optional[str] = None
+    pipeline_stage: Optional[int] = None
+    branch_outcome: Optional[str] = None
+    exception_type: Optional[str] = None
+    cache_state: Optional[str] = None
+    data_size: Optional[int] = None
+    alignment: Optional[int] = None
+    privilege_level: Optional[str] = None
+    csr: Optional[str] = None
+    memory_pattern: Optional[str] = None
+
+
+def generate_trace(rand: random.Random, riscv_data: RISCVDataset) -> InstructionTrace:
+    """Generate a random instruction trace that exercises the stress tree."""
+    format_type = rand.choice(riscv_data.instruction_formats)
+    category = rand.choice(riscv_data.instruction_categories)
+    instruction_type = rand.choice(riscv_data.instruction_types)
+    opcode = rand.choice(riscv_data.opcodes)
+
+    rd = rand.choice(riscv_data.registers) if rand.random() > 0.1 else None
+    rs1 = rand.choice(riscv_data.registers) if rand.random() > 0.2 else None
+    rs2 = rand.choice(riscv_data.registers) if rand.random() > 0.3 else None
+    immediate = rand.randint(-2048, 2047) if rand.random() > 0.4 else None
+    execution_state = (
+        rand.choice(riscv_data.execution_states) if rand.random() > 0.3 else None
+    )
+    pipeline_stage = (
+        rand.choice(riscv_data.pipeline_stages) if rand.random() > 0.2 else None
+    )
+
+    branch_outcome = None
+    if format_type == "B-type" or category == "Branch":
+        branch_outcome = rand.choice(riscv_data.branch_outcomes)
+
+    exception_type = "none"
+    if rand.random() < 0.05:
+        exception_type = rand.choice(riscv_data.exception_types)
+
+    cache_state = None
+    data_size = None
+    alignment = None
+    memory_pattern = None
+    if category in ("Load", "Store"):
+        cache_state = rand.choice(riscv_data.cache_states)
+        data_size = rand.choice(riscv_data.data_sizes)
+        alignment = rand.choice(riscv_data.alignments)
+        memory_pattern = rand.choice(riscv_data.memory_patterns)
+
+    privilege_level = (
+        rand.choice(riscv_data.privilege_levels) if rand.random() > 0.5 else "user"
+    )
+
+    csr = None
+    if category == "System" and rand.random() < 0.3:
+        csr = rand.choice(riscv_data.csr_registers)
+
+    return InstructionTrace(
+        opcode=opcode,
+        format_type=format_type,
+        category=category,
+        instruction_type=instruction_type,
+        rd=rd,
+        rs1=rs1,
+        rs2=rs2,
+        immediate=immediate,
+        execution_state=execution_state,
+        pipeline_stage=pipeline_stage,
+        branch_outcome=branch_outcome,
+        exception_type=exception_type,
+        cache_state=cache_state,
+        data_size=data_size,
+        alignment=alignment,
+        privilege_level=privilege_level,
+        csr=csr,
+        memory_pattern=memory_pattern,
+    )
+
+
+def context_hash() -> str:
+    """Git HEAD of the repo, or empty string if git is unavailable."""
+    repo_root = Path(__file__).resolve().parents[2]
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return ""
+
+
+def iter_coverpoints(node):
+    if isinstance(node, Coverpoint):
+        yield node
+        return
+    for child in node.iter_children():
+        yield from iter_coverpoints(child)
+
+
+def tree_stats(top: Covertop) -> dict[str, int]:
+    coverpoints = list(iter_coverpoints(top))
+    buckets = 0
+    for coverpoint in coverpoints:
+        sizes = [axis.size for axis in coverpoint._axes]
+        buckets += math.prod(sizes) if sizes else 1
+    return {
+        "coverpoints": len(coverpoints),
+        "covergroups": _count_covergroups(top),
+        "buckets": buckets,
+    }
+
+
+def _count_covergroups(node) -> int:
+    if isinstance(node, Coverpoint):
+        return 0
+    count = 1
+    for child in node.iter_children():
+        count += _count_covergroups(child)
+    return count
+
+
+def build_coverage(
+    *,
+    copies: int = 1,
+    source: str = "",
+    source_key: str | int = "",
+    riscv_data: RISCVDataset | None = None,
+) -> StressTop:
+    data = riscv_data or RISCVDataset()
+    with CoverageContext(riscv_data=data):
+        return StressTop(copies=copies, source=source, source_key=source_key)

--- a/examples/riscv_stress/stress_example.py
+++ b/examples/riscv_stress/stress_example.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from pathlib import Path
+
+from bucket.rw import (
+    ArchiveAccessor,
+    JSONAccessor,
+    PointReader,
+    SQLAccessor,
+)
+
+from .stress_common import (
+    RISCVDataset,
+    build_coverage,
+    context_hash,
+    generate_trace,
+    tree_stats,
+)
+
+FORMAT_ACCESSORS = {
+    "archive": (ArchiveAccessor, "bktgz"),
+    "sql": (lambda path: SQLAccessor.File(path), "db"),
+    "json": (JSONAccessor, "json"),
+}
+
+FORMAT_MERGE = {
+    "archive": ArchiveAccessor.merge_files,
+    "sql": SQLAccessor.merge_files,
+    "json": JSONAccessor.merge_files,
+}
+
+
+def parse_formats(formats: list[str] | None) -> list[str]:
+    if not formats or "both" in formats:
+        return ["archive", "sql"]
+    if "all" in formats:
+        return ["archive", "sql", "json"]
+    known = {"archive", "sql", "json"}
+    unknown = [fmt for fmt in formats if fmt not in known]
+    if unknown:
+        raise ValueError(f"Unknown formats: {unknown}. Choose from {sorted(known)}")
+    return list(dict.fromkeys(formats))
+
+
+def export_readout(
+    readout, output_dir: Path, stem: str, formats: list[str]
+) -> dict[str, Path]:
+    paths = {}
+    for fmt in formats:
+        accessor_cls, ext = FORMAT_ACCESSORS[fmt]
+        fmt_dir = output_dir / fmt
+        fmt_dir.mkdir(parents=True, exist_ok=True)
+        path = fmt_dir / f"{stem}.{ext}"
+        accessor_cls(path).write(readout)
+        paths[fmt] = path
+    return paths
+
+
+def merge_format(
+    log: logging.Logger,
+    paths: list[Path],
+    merged_path: Path,
+    fmt: str,
+) -> float:
+    if not paths:
+        log.error("No %s files to merge", fmt)
+        return 0.0
+    log.info("Merging %d %s files into %s", len(paths), fmt, merged_path)
+    start = time.perf_counter()
+    merged = FORMAT_MERGE[fmt](paths)
+    if merged is None:
+        log.error("Merge produced no readout for %s", fmt)
+        return 0.0
+    accessor_cls, _ = FORMAT_ACCESSORS[fmt]
+    merged_path.parent.mkdir(parents=True, exist_ok=True)
+    accessor_cls(merged_path).write(merged)
+    elapsed = time.perf_counter() - start
+    log.info("Merged %s in %.2fs -> %s", fmt, elapsed, merged_path)
+    return elapsed
+
+
+def run_one_test(
+    *,
+    test_num: int,
+    rand: random.Random,
+    log: logging.Logger,
+    riscv_data: RISCVDataset,
+    output_dir: Path,
+    formats: list[str],
+    samples: int,
+    copies: int,
+) -> dict[str, Path]:
+    log.info("Test %d: building tree and sampling %d traces", test_num, samples)
+    cvg = build_coverage(
+        copies=copies,
+        source=f"stress_test_{test_num:03d}",
+        source_key=str(rand.randint(1, 1_000_000)),
+        riscv_data=riscv_data,
+    )
+    for _ in range(samples):
+        cvg.sample(generate_trace(rand, riscv_data))
+
+    readout = PointReader(context_hash()).read(cvg)
+    return export_readout(readout, output_dir, f"test_{test_num:03d}", formats)
+
+
+def run(
+    output_dir: Path = Path("output"),
+    num_tests: int = 10,
+    seed: int = 42,
+    export_formats: list[str] | None = None,
+    samples_per_test: int | None = None,
+    copies: int = 1,
+):
+    """Sample the stress tree, export each run, and merge the results."""
+    formats = parse_formats(export_formats)
+    logging.basicConfig(level=logging.INFO)
+    log = logging.getLogger("stress_test")
+    riscv_data = RISCVDataset()
+
+    stress_output_dir = output_dir / "riscv_stress"
+    test_outputs_dir = stress_output_dir / "test_outputs"
+    test_outputs_dir.mkdir(parents=True, exist_ok=True)
+
+    log.info(
+        "Starting stress run: %d tests, formats=%s, copies=%d",
+        num_tests,
+        formats,
+        copies,
+    )
+
+    exported: dict[str, list[Path]] = {fmt: [] for fmt in formats}
+    for test_num in range(num_tests):
+        test_rand = random.Random(seed + test_num)
+        samples = (
+            samples_per_test
+            if samples_per_test is not None
+            else test_rand.randint(100, 500)
+        )
+        try:
+            paths = run_one_test(
+                test_num=test_num,
+                rand=test_rand,
+                log=log,
+                riscv_data=riscv_data,
+                output_dir=test_outputs_dir,
+                formats=formats,
+                samples=samples,
+                copies=copies,
+            )
+        except Exception:
+            log.exception("Test %d failed", test_num)
+            continue
+        for fmt, path in paths.items():
+            exported[fmt].append(path)
+        if (test_num + 1) % 10 == 0 or test_num + 1 == num_tests:
+            log.info("Completed %d/%d tests", test_num + 1, num_tests)
+
+    times: dict[str, float] = {}
+    for fmt, paths in exported.items():
+        if not paths:
+            continue
+        _, ext = FORMAT_ACCESSORS[fmt]
+        merged_path = stress_output_dir / f"riscv_stress_merged.{ext}"
+        times[fmt] = merge_format(log, paths, merged_path, fmt)
+
+    log.info("=" * 60)
+    log.info("Stress run complete")
+    log.info("Individual outputs: %s", test_outputs_dir)
+    for fmt, elapsed in times.items():
+        log.info("  %s merge: %.2fs", fmt, elapsed)
+    if len(times) >= 2:
+        ordered = sorted(times.items(), key=lambda item: item[1])
+        fastest, slowest = ordered[0], ordered[-1]
+        if fastest[1] > 0:
+            log.info(
+                "  %s was %.2fx faster than %s",
+                fastest[0],
+                slowest[1] / fastest[1],
+                slowest[0],
+            )
+    log.info("=" * 60)
+
+
+def bench_sample(
+    *,
+    iters: int = 50_000,
+    warmup: int = 1_000,
+    copies: int = 1,
+    seed: int = 42,
+) -> dict[str, float | int]:
+    """Time Covertop.sample against the full (optionally replicated) stress tree."""
+    logging.basicConfig(level=logging.INFO)
+    log = logging.getLogger("stress_sample")
+    riscv_data = RISCVDataset()
+    rand = random.Random(seed)
+
+    log.info("Building stress tree (copies=%d)...", copies)
+    build_start = time.perf_counter()
+    cvg = build_coverage(copies=copies, source="sample_bench", riscv_data=riscv_data)
+    build_seconds = time.perf_counter() - build_start
+    stats = tree_stats(cvg)
+    log.info(
+        "Tree ready in %.2fs: %d coverpoints, %d covergroups, %d buckets",
+        build_seconds,
+        stats["coverpoints"],
+        stats["covergroups"],
+        stats["buckets"],
+    )
+
+    traces = [generate_trace(rand, riscv_data) for _ in range(max(iters, warmup))]
+    for trace in traces[:warmup]:
+        cvg.sample(trace)
+
+    sample_start = time.perf_counter()
+    for trace in traces[:iters]:
+        cvg.sample(trace)
+    sample_seconds = time.perf_counter() - sample_start
+    per_sec = iters / sample_seconds if sample_seconds else float("inf")
+    us_per_sample = (sample_seconds / iters) * 1e6 if iters else 0.0
+
+    log.info("=" * 60)
+    log.info("Sampling stress")
+    log.info("  copies:          %d", copies)
+    log.info("  coverpoints:     %d", stats["coverpoints"])
+    log.info("  buckets:         %d", stats["buckets"])
+    log.info("  build:           %.3fs", build_seconds)
+    log.info("  warmup:          %d", warmup)
+    log.info("  iters:           %d", iters)
+    log.info("  sample time:     %.3fs", sample_seconds)
+    log.info("  samples/sec:     %.0f", per_sec)
+    log.info("  us/sample:       %.2f", us_per_sample)
+    log.info("=" * 60)
+
+    return {
+        "copies": copies,
+        "coverpoints": stats["coverpoints"],
+        "covergroups": stats["covergroups"],
+        "buckets": stats["buckets"],
+        "build_seconds": build_seconds,
+        "iters": iters,
+        "sample_seconds": sample_seconds,
+        "samples_per_sec": per_sec,
+        "us_per_sample": us_per_sample,
+    }

--- a/examples/riscv_stress/stress_modules/__init__.py
+++ b/examples/riscv_stress/stress_modules/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved

--- a/examples/riscv_stress/stress_modules/module_00.py
+++ b/examples/riscv_stress/stress_modules/module_00.py
@@ -1,0 +1,455 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from bucket import AxisUtils, Covergroup, Coverpoint
+
+
+# Level 1: Top-level covergroup for instruction formats
+class InstructionFormatGroup(Covergroup):
+    NAME = "instruction_formats"
+    DESCRIPTION = "Coverage for RISC-V instruction formats"
+
+    def setup(self, ctx):
+        self.add_covergroup(RTypeGroup())
+        self.add_covergroup(ITypeGroup())
+        self.add_covergroup(BranchTypeGroup())
+
+
+# Level 2: R-type instructions
+class RTypeGroup(Covergroup):
+    NAME = "r_type"
+    DESCRIPTION = "R-type instruction coverage"
+
+    def should_sample(self, trace):
+        return trace.format_type == "R-type"
+
+    def setup(self, ctx):
+        self.add_coverpoint(RTypeArithmetic())  # Small: ~100 buckets
+        self.add_coverpoint(RTypeLogical())  # Medium: ~300 buckets
+        self.add_covergroup(RTypeAdvanced())  # Nested group
+
+
+# Level 3: Advanced R-type
+class RTypeAdvanced(Covergroup):
+    NAME = "r_type_advanced"
+    DESCRIPTION = "Advanced R-type coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(RTypeShift())  # Large: ~800 buckets
+
+
+# Small coverpoint: ~100 buckets (3 axes: 5, 4, 5 values)
+class RTypeArithmetic(Coverpoint):
+    NAME = "r_type_arithmetic"
+    DESCRIPTION = "R-type arithmetic operations"
+    TIER = 1
+    TAGS = ["arithmetic", "r-type"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="opcode",
+            values=list(range(5)),
+            description="Arithmetic opcodes",
+        )
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:4],
+            description="Destination register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 1",
+            enable_other="Other",
+        )
+
+        # Add target goal for specific combinations
+        self.add_goal("HIGH_PRIORITY", "High priority arithmetic ops", target=100)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.opcode.name == "0" and bucket.rd.name in ["x0", "x1"]:
+            return goals.HIGH_PRIORITY
+
+    def should_sample(self, trace):
+        return trace.category == "Arithmetic"
+
+    def sample(self, trace):
+        self.bucket.clear()
+        self.bucket.set_axes(
+            opcode=trace.opcode % 5,
+            rd=trace.rd if trace.rd else "x0",
+            rs1=trace.rs1 if trace.rs1 else "x0",
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~300 buckets (4 axes: 6, 5, 5, 2 values)
+class RTypeLogical(Coverpoint):
+    NAME = "r_type_logical"
+    DESCRIPTION = "R-type logical operations"
+    TIER = 2
+    TAGS = ["logical", "r-type"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="opcode",
+            values=list(range(6)),
+            description="Logical opcodes",
+        )
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:5],
+            description="Destination register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 1",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs2",
+            values=ctx.riscv_data.registers[:2],
+            description="Source register 2",
+            enable_other="Other",
+        )
+
+        # Add target goal for x0 usage (should be rare)
+        self.add_goal("ZERO_DEST", "Using x0 as destination should be rare", target=200)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.rd.name == "x0":
+            return goals.ZERO_DEST
+
+    def should_sample(self, trace):
+        return trace.category == "Logical"
+
+    def sample(self, trace):
+        self.bucket.clear()
+        self.bucket.set_axes(
+            opcode=trace.opcode % 6,
+            rd=trace.rd if trace.rd else "x0",
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            rs2=trace.rs2 if trace.rs2 else "x0",
+        )
+        self.bucket.hit()
+
+
+# Large coverpoint: ~800 buckets (4 axes: 5, 4, 5, 4 values)
+class RTypeShift(Coverpoint):
+    NAME = "r_type_shift"
+    DESCRIPTION = "R-type shift operations"
+    TIER = 3
+    TAGS = ["shift", "r-type"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="shift_type",
+            values=["SLL", "SRL", "SRA", "SLLI", "SRLI"],
+            description="Shift operation type",
+        )
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:4],
+            description="Destination register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 1",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="shift_amount",
+            values=AxisUtils.ranges(31, 4, min_val=0),
+            description="Shift amount ranges",
+            enable_other="Other",
+        )
+
+        # Add target goal
+        self.add_goal(
+            "LARGE_SHIFT", "Large shift amounts need more coverage", target=200
+        )
+
+    def apply_goals(self, bucket, goals):
+        if (
+            "30 -> 31" in bucket.shift_amount.name
+            or "28 -> 29" in bucket.shift_amount.name
+        ):
+            return goals.LARGE_SHIFT
+
+    def should_sample(self, trace):
+        if trace.category != "Shift":
+            return False
+        shift_type = trace.instruction_type if trace.instruction_type else "SLL"
+        return shift_type in ["SLL", "SRL", "SRA", "SLLI", "SRLI"]
+
+    def sample(self, trace):
+        shift_type = trace.instruction_type if trace.instruction_type else "SLL"
+        shift_amount = trace.immediate if trace.immediate is not None else 0
+        # Clamp to valid range [0, 31] - values outside will be caught by enable_other
+        if shift_amount > 31:
+            shift_amount = 31
+        # Negative values will be handled by enable_other
+        self.bucket.clear()
+        self.bucket.set_axes(
+            shift_type=shift_type,
+            rd=trace.rd if trace.rd else "x0",
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            shift_amount=shift_amount,
+        )
+        self.bucket.hit()
+
+
+# Level 2: I-type instructions
+class ITypeGroup(Covergroup):
+    NAME = "i_type"
+    DESCRIPTION = "I-type instruction coverage"
+
+    def should_sample(self, trace):
+        return trace.format_type == "I-type"
+
+    def setup(self, ctx):
+        self.add_coverpoint(ITypeLoad())  # Small: ~80 buckets
+        self.add_coverpoint(ITypeImmediate())  # Medium: ~400 buckets
+
+
+# Small coverpoint: ~80 buckets (3 axes: 4, 5, 4 values)
+class ITypeLoad(Coverpoint):
+    NAME = "i_type_load"
+    DESCRIPTION = "I-type load operations"
+    TIER = 1
+    TAGS = ["load", "i-type"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="load_type",
+            values=["LW", "LH", "LB", "LHU"],
+            description="Load instruction type",
+        )
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:5],
+            description="Destination register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:4],
+            description="Base register",
+            enable_other="Other",
+        )
+
+        # Add ignore goal
+        self.add_goal("IGNORE_X0", "Ignore loads to x0", ignore=True)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.rd.name == "x0":
+            return goals.IGNORE_X0
+
+    def should_sample(self, trace):
+        if trace.category != "Load":
+            return False
+        load_type = trace.instruction_type if trace.instruction_type else "LW"
+        return load_type in ["LW", "LH", "LB", "LHU"]
+
+    def sample(self, trace):
+        load_type = trace.instruction_type if trace.instruction_type else "LW"
+        self.bucket.clear()
+        self.bucket.set_axes(
+            load_type=load_type,
+            rd=trace.rd if trace.rd else "x0",
+            rs1=trace.rs1 if trace.rs1 else "x0",
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~400 buckets (4 axes: 5, 4, 5, 4 values)
+class ITypeImmediate(Coverpoint):
+    NAME = "i_type_immediate"
+    DESCRIPTION = "I-type immediate operations"
+    TIER = 2
+    TAGS = ["immediate", "i-type"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="opcode",
+            values=list(range(5)),
+            description="Immediate opcodes",
+        )
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:4],
+            description="Destination register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 1",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="immediate",
+            values=AxisUtils.ranges(4095, 4, min_val=0),
+            description="Immediate value ranges",
+            enable_other="Other",
+        )
+
+        # Add target goal
+        self.add_goal("LARGE_IMM", "Large immediate values", target=150)
+
+    def apply_goals(self, bucket, goals):
+        if "3072 -> 4095" in bucket.immediate.name:
+            return goals.LARGE_IMM
+
+    def sample(self, trace):
+        self.bucket.clear()
+        # Clamp immediate to valid range [0, 4095]
+        imm_val = trace.immediate if trace.immediate is not None else 0
+        if imm_val < 0 or imm_val > 4095:
+            imm_val = "Other"
+        self.bucket.set_axes(
+            opcode=trace.opcode % 5,
+            rd=trace.rd if trace.rd else "x0",
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            immediate=imm_val,
+        )
+        self.bucket.hit()
+
+
+# Level 2: Branch instructions
+class BranchTypeGroup(Covergroup):
+    NAME = "branch_type"
+    DESCRIPTION = "Branch instruction coverage"
+
+    def should_sample(self, trace):
+        return trace.format_type == "B-type"
+
+    def setup(self, ctx):
+        self.add_coverpoint(BranchOperations())  # Medium: ~250 buckets
+        self.add_covergroup(BranchAdvanced())  # Nested group
+
+
+# Level 3: Advanced branch
+class BranchAdvanced(Covergroup):
+    NAME = "branch_advanced"
+    DESCRIPTION = "Advanced branch coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(BranchPrediction())  # Large: ~600 buckets
+
+
+# Medium coverpoint: ~250 buckets (3 axes: 5, 5, 10 values)
+class BranchOperations(Coverpoint):
+    NAME = "branch_operations"
+    DESCRIPTION = "Branch operation types"
+    TIER = 2
+    TAGS = ["branch", "control-flow"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="branch_type",
+            values=["BEQ", "BNE", "BLT", "BGE", "BLTU"],
+            description="Branch instruction type",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 1",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs2",
+            values=ctx.riscv_data.registers[:10],
+            description="Source register 2",
+            enable_other="Other",
+        )
+
+        # Add ignore goal for x0 branch (not interesting)
+        self.add_goal("ZERO_BRANCH", "Branching on x0 is not interesting", ignore=True)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.rs1.name == "x0" and bucket.rs2.name == "x0":
+            return goals.ZERO_BRANCH
+
+    def should_sample(self, trace):
+        if trace.category != "Branch":
+            return False
+        branch_type = trace.instruction_type if trace.instruction_type else "BEQ"
+        return branch_type in ["BEQ", "BNE", "BLT", "BGE", "BLTU"]
+
+    def sample(self, trace):
+        branch_type = trace.instruction_type if trace.instruction_type else "BEQ"
+        self.bucket.clear()
+        self.bucket.set_axes(
+            branch_type=branch_type,
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            rs2=trace.rs2 if trace.rs2 else "x0",
+        )
+        self.bucket.hit()
+
+
+# Large coverpoint: ~600 buckets (4 axes: 5, 4, 5, 3 values)
+class BranchPrediction(Coverpoint):
+    NAME = "branch_prediction"
+    DESCRIPTION = "Branch prediction coverage"
+    TIER = 3
+    TAGS = ["branch", "prediction"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="branch_type",
+            values=["BEQ", "BNE", "BLT", "BGE", "BLTU"],
+            description="Branch instruction type",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="outcome",
+            values=ctx.riscv_data.branch_outcomes,
+            description="Branch outcome",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 1",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="pipeline_stage",
+            values=ctx.riscv_data.pipeline_stages[:3],
+            description="Pipeline stage",
+            enable_other="Other",
+        )
+
+        # Add target goal
+        self.add_goal(
+            "MISPREDICT", "Mispredicted branches need more coverage", target=300
+        )
+
+    def apply_goals(self, bucket, goals):
+        if bucket.outcome.name == "mispredicted":
+            return goals.MISPREDICT
+
+    def should_sample(self, trace):
+        if trace.branch_outcome is None:
+            return False
+        branch_type = trace.instruction_type if trace.instruction_type else "BEQ"
+        return branch_type in ["BEQ", "BNE", "BLT", "BGE", "BLTU"]
+
+    def sample(self, trace):
+        branch_type = trace.instruction_type if trace.instruction_type else "BEQ"
+        self.bucket.clear()
+        self.bucket.set_axes(
+            branch_type=branch_type,
+            outcome=trace.branch_outcome,
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            pipeline_stage=trace.pipeline_stage
+            if trace.pipeline_stage is not None
+            else 0,
+        )
+        self.bucket.hit()

--- a/examples/riscv_stress/stress_modules/module_01.py
+++ b/examples/riscv_stress/stress_modules/module_01.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from bucket import AxisUtils, Covergroup, Coverpoint
+
+
+# Level 1: Memory operations
+class MemoryGroup(Covergroup):
+    NAME = "memory_operations"
+    DESCRIPTION = "Memory operation coverage"
+
+    def should_sample(self, trace):
+        return trace.category in ("Load", "Store")
+
+    def setup(self, ctx):
+        self.add_coverpoint(LoadOperations())  # Small: ~120 buckets
+        self.add_coverpoint(StoreOperations())  # Medium: ~350 buckets
+        self.add_covergroup(MemoryAdvanced())  # Nested group
+
+
+# Level 2: Advanced memory
+class MemoryAdvanced(Covergroup):
+    NAME = "memory_advanced"
+    DESCRIPTION = "Advanced memory coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(CacheOperations())  # Large: ~1000 buckets
+        self.add_covergroup(MemoryAlignment())  # Level 3 nested
+
+
+# Level 3: Memory alignment
+class MemoryAlignment(Covergroup):
+    NAME = "memory_alignment"
+    DESCRIPTION = "Memory alignment coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(AlignmentCoverage())  # Medium: ~240 buckets
+
+
+# Small coverpoint: ~120 buckets (3 axes: 4, 5, 6 values)
+class LoadOperations(Coverpoint):
+    NAME = "load_operations"
+    DESCRIPTION = "Load operation coverage"
+    TIER = 1
+    TAGS = ["load", "memory"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="load_type",
+            values=["LW", "LH", "LB", "LHU"],
+            description="Load instruction type",
+        )
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:5],
+            description="Destination register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="data_size",
+            values=ctx.riscv_data.data_sizes,
+            description="Data size in bits",
+        )
+
+        # Add target goal
+        self.add_goal("WORD_LOAD", "Word loads are common", target=50)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.load_type.name == "LW" and bucket.data_size.value == 32:
+            return goals.WORD_LOAD
+
+    def should_sample(self, trace):
+        if trace.category != "Load":
+            return False
+        load_type = trace.instruction_type if trace.instruction_type else "LW"
+        return load_type in ["LW", "LH", "LB", "LHU"]
+
+    def sample(self, trace):
+        load_type = trace.instruction_type if trace.instruction_type else "LW"
+        self.bucket.clear()
+        self.bucket.set_axes(
+            load_type=load_type,
+            rd=trace.rd if trace.rd else "x0",
+            data_size=trace.data_size if trace.data_size else 32,
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~350 buckets (4 axes: 5, 4, 5, 3 values)
+class StoreOperations(Coverpoint):
+    NAME = "store_operations"
+    DESCRIPTION = "Store operation coverage"
+    TIER = 2
+    TAGS = ["store", "memory"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="store_type",
+            values=["SW", "SH", "SB"],
+            description="Store instruction type",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:4],
+            description="Base register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs2",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="alignment",
+            values=ctx.riscv_data.alignments[:3],
+            description="Address alignment",
+            enable_other="Other",
+        )
+
+        # Add ignore goal for x0 store (not interesting)
+        self.add_goal("ZERO_STORE", "Storing from x0 is not interesting", ignore=True)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.rs2.name == "x0":
+            return goals.ZERO_STORE
+
+    def should_sample(self, trace):
+        if trace.category != "Store":
+            return False
+        store_type = trace.instruction_type if trace.instruction_type else "SW"
+        return store_type in ["SW", "SH", "SB"]
+
+    def sample(self, trace):
+        store_type = trace.instruction_type if trace.instruction_type else "SW"
+        self.bucket.clear()
+        self.bucket.set_axes(
+            store_type=store_type,
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            rs2=trace.rs2 if trace.rs2 else "x0",
+            alignment=trace.alignment if trace.alignment else 4,
+        )
+        self.bucket.hit()
+
+
+# Large coverpoint: ~1000 buckets (5 axes: 4, 5, 5, 4, 2 values)
+class CacheOperations(Coverpoint):
+    NAME = "cache_operations"
+    DESCRIPTION = "Cache operation coverage"
+    TIER = 3
+    TAGS = ["cache", "memory"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="cache_state",
+            values=ctx.riscv_data.cache_states,
+            description="Cache state",
+        )
+        self.add_axis(
+            name="memory_pattern",
+            values=ctx.riscv_data.memory_patterns,
+            description="Memory access pattern",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Base register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="data_size",
+            values=ctx.riscv_data.data_sizes,
+            description="Data size",
+        )
+        self.add_axis(
+            name="privilege",
+            values=ctx.riscv_data.privilege_levels[:2],
+            description="Privilege level",
+            enable_other="Other",
+        )
+
+        # Add target goal
+        self.add_goal("CACHE_MISS", "Cache misses need more coverage", target=500)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.cache_state.name == "miss":
+            return goals.CACHE_MISS
+
+    def should_sample(self, trace):
+        return trace.cache_state is not None
+
+    def sample(self, trace):
+        self.bucket.clear()
+        self.bucket.set_axes(
+            cache_state=trace.cache_state,
+            memory_pattern=trace.memory_pattern
+            if trace.memory_pattern
+            else "sequential",
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            data_size=trace.data_size if trace.data_size else 32,
+            privilege=trace.privilege_level if trace.privilege_level else "user",
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~240 buckets (4 axes: 4, 4, 5, 3 values)
+class AlignmentCoverage(Coverpoint):
+    NAME = "alignment_coverage"
+    DESCRIPTION = "Memory alignment coverage"
+    TIER = 2
+    TAGS = ["alignment", "memory"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="alignment",
+            values=ctx.riscv_data.alignments,
+            description="Address alignment",
+        )
+        self.add_axis(
+            name="data_size",
+            values=ctx.riscv_data.data_sizes,
+            description="Data size",
+        )
+        self.add_axis(
+            name="address",
+            values=AxisUtils.ranges(1023, 5, min_val=0),
+            description="Address ranges",
+        )
+        self.add_axis(
+            name="operation",
+            values=["load", "store"],
+            description="Memory operation type",
+        )
+
+        # Add target goal for misaligned access (needs more coverage)
+        self.add_goal("MISALIGNED", "Misaligned access needs more coverage", target=300)
+
+    def apply_goals(self, bucket, goals):
+        # Check if alignment matches data size requirement
+        align_val = (
+            4 if bucket.alignment.name == "Other" else int(bucket.alignment.value)
+        )
+        size_val = int(bucket.data_size.value) // 8
+        if align_val < size_val:
+            return goals.MISALIGNED
+
+    def should_sample(self, trace):
+        return trace.alignment is not None
+
+    def sample(self, trace):
+        self.bucket.clear()
+        # Alignment value - enable_other will handle values not in [1, 2, 4]
+        align_val = trace.alignment if trace.alignment else 4
+        self.bucket.set_axes(
+            alignment=align_val,
+            data_size=trace.data_size if trace.data_size else 32,
+            address=(trace.immediate if trace.immediate is not None else 0) % 1024,
+            operation="load" if trace.category == "Load" else "store",
+        )
+        self.bucket.hit()

--- a/examples/riscv_stress/stress_modules/module_02.py
+++ b/examples/riscv_stress/stress_modules/module_02.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from bucket import AxisUtils, Covergroup, Coverpoint
+
+
+# Level 1: Pipeline coverage
+class PipelineGroup(Covergroup):
+    NAME = "pipeline"
+    DESCRIPTION = "Pipeline stage coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(PipelineStages())  # Small: ~150 buckets
+        self.add_covergroup(PipelineHazards())  # Nested group
+        self.add_coverpoint(PipelineFlush())  # Medium: ~280 buckets
+
+
+# Level 2: Pipeline hazards
+class PipelineHazards(Covergroup):
+    NAME = "pipeline_hazards"
+    DESCRIPTION = "Pipeline hazard coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(DataHazards())  # Large: ~750 buckets
+        self.add_coverpoint(ControlHazards())  # Medium: ~320 buckets
+
+
+# Small coverpoint: ~150 buckets (3 axes: 5, 5, 6 values)
+class PipelineStages(Coverpoint):
+    NAME = "pipeline_stages"
+    DESCRIPTION = "Pipeline stage coverage"
+    TIER = 1
+    TAGS = ["pipeline", "stages"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="stage",
+            values=ctx.riscv_data.pipeline_stages,
+            description="Pipeline stage",
+        )
+        self.add_axis(
+            name="execution_state",
+            values=ctx.riscv_data.execution_states[:5],
+            description="Execution state",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="instruction_type",
+            values=ctx.riscv_data.instruction_types[:6],
+            description="Instruction type",
+            enable_other="Other",
+        )
+
+        # Add target goal
+        self.add_goal("EXECUTE_STAGE", "Execute stage is critical", target=100)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.stage.name == "2" and bucket.execution_state.name == "execute":
+            return goals.EXECUTE_STAGE
+
+    def should_sample(self, trace):
+        return trace.pipeline_stage is not None
+
+    def sample(self, trace):
+        # Validate execution_state
+        exec_state = trace.execution_state if trace.execution_state else "idle"
+        if exec_state not in ["idle", "fetch", "decode", "execute", "memory"]:
+            exec_state = "Other"
+        # Validate instruction_type
+        inst_type = trace.instruction_type if trace.instruction_type else "ADD"
+        valid_types = ["ADD", "SUB", "AND", "OR", "XOR", "SLT"]
+        if inst_type not in valid_types:
+            inst_type = "Other"
+        self.bucket.clear()
+        self.bucket.set_axes(
+            stage=str(trace.pipeline_stage),
+            execution_state=exec_state,
+            instruction_type=inst_type,
+        )
+        self.bucket.hit()
+
+
+# Large coverpoint: ~750 buckets (5 axes: 5, 3, 5, 5, 2 values)
+class DataHazards(Coverpoint):
+    NAME = "data_hazards"
+    DESCRIPTION = "Data hazard coverage"
+    TIER = 3
+    TAGS = ["pipeline", "hazards"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="hazard_type",
+            values=["RAW", "WAR", "WAW", "structural", "none"],
+            description="Data hazard type",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:3],
+            description="Source register 1",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs2",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 2",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:5],
+            description="Destination register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="stall_cycles",
+            values=AxisUtils.one_hot(2, include_zero=True),
+            description="Stall cycles (one-hot)",
+        )
+
+        # Add target goal
+        self.add_goal("RAW_HAZARD", "RAW hazards need more coverage", target=400)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.hazard_type.name == "RAW":
+            return goals.RAW_HAZARD
+
+    def sample(self, trace):
+        # Simulate data hazard detection
+        hazard_type = "none"
+        if trace.rs1 and trace.rd:
+            if trace.rs1 == trace.rd:
+                hazard_type = "RAW"
+        stall_cycles = 0 if hazard_type == "none" else 1
+        self.bucket.clear()
+        self.bucket.set_axes(
+            hazard_type=hazard_type,
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            rs2=trace.rs2 if trace.rs2 else "x0",
+            rd=trace.rd if trace.rd else "x0",
+            stall_cycles=stall_cycles,
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~320 buckets (4 axes: 4, 5, 4, 4 values)
+class ControlHazards(Coverpoint):
+    NAME = "control_hazards"
+    DESCRIPTION = "Control hazard coverage"
+    TIER = 2
+    TAGS = ["pipeline", "control"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="branch_outcome",
+            values=ctx.riscv_data.branch_outcomes,
+            description="Branch outcome",
+        )
+        self.add_axis(
+            name="pipeline_stage",
+            values=ctx.riscv_data.pipeline_stages[:5],
+            description="Pipeline stage",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="flush_depth",
+            values=AxisUtils.ranges(4, 4, min_val=0),
+            description="Pipeline flush depth",
+        )
+        self.add_axis(
+            name="instruction_type",
+            values=ctx.riscv_data.instruction_types[:4],
+            description="Instruction type",
+            enable_other="Other",
+        )
+
+        # Add ignore goal
+        self.add_goal("IGNORE_NO_FLUSH", "Ignore non-flush cases", ignore=True)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.flush_depth.name == "0":
+            return goals.IGNORE_NO_FLUSH
+
+    def should_sample(self, trace):
+        return trace.branch_outcome is not None
+
+    def sample(self, trace):
+        flush_depth = 0 if trace.branch_outcome == "not_taken" else 2
+        self.bucket.clear()
+        self.bucket.set_axes(
+            branch_outcome=trace.branch_outcome,
+            pipeline_stage=str(trace.pipeline_stage)
+            if trace.pipeline_stage is not None and trace.pipeline_stage < 5
+            else "Other",
+            flush_depth=flush_depth,
+            instruction_type=trace.instruction_type
+            if trace.instruction_type
+            else "BEQ",
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~280 buckets (4 axes: 5, 4, 5, 3 values)
+class PipelineFlush(Coverpoint):
+    NAME = "pipeline_flush"
+    DESCRIPTION = "Pipeline flush coverage"
+    TIER = 2
+    TAGS = ["pipeline", "flush"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="flush_reason",
+            values=["branch_mispredict", "exception", "interrupt", "none", "reset"],
+            description="Flush reason",
+        )
+        self.add_axis(
+            name="flush_depth",
+            values=AxisUtils.ranges(4, 4, min_val=0),
+            description="Pipeline flush depth",
+        )
+        self.add_axis(
+            name="pipeline_stage",
+            values=ctx.riscv_data.pipeline_stages[:5],
+            description="Pipeline stage",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="privilege",
+            values=ctx.riscv_data.privilege_levels,
+            description="Privilege level",
+            enable_other="Other",
+        )
+
+        # Add target goal for reset flush (needs more coverage)
+        self.add_goal("RESET_FLUSH", "Reset flush needs more coverage", target=250)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.flush_reason.name == "reset":
+            return goals.RESET_FLUSH
+
+    def sample(self, trace):
+        flush_reason = "none"
+        if trace.exception_type and trace.exception_type != "none":
+            flush_reason = "exception"
+        elif trace.branch_outcome == "mispredicted":
+            flush_reason = "branch_mispredict"
+        self.bucket.clear()
+        self.bucket.set_axes(
+            flush_reason=flush_reason,
+            flush_depth=2 if flush_reason != "none" else 0,
+            pipeline_stage=str(trace.pipeline_stage)
+            if trace.pipeline_stage is not None and trace.pipeline_stage < 5
+            else "Other",
+            privilege=trace.privilege_level if trace.privilege_level else "user",
+        )
+        self.bucket.hit()

--- a/examples/riscv_stress/stress_modules/module_03.py
+++ b/examples/riscv_stress/stress_modules/module_03.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from bucket import Covergroup, Coverpoint
+
+
+# Level 1: Exception handling
+class ExceptionGroup(Covergroup):
+    NAME = "exceptions"
+    DESCRIPTION = "Exception handling coverage"
+
+    def should_sample(self, trace):
+        return trace.exception_type is not None
+
+    def setup(self, ctx):
+        self.add_coverpoint(ExceptionTypes())  # Small: ~100 buckets
+        self.add_covergroup(ExceptionHandling())  # Nested group
+
+
+# Level 2: Exception handling
+class ExceptionHandling(Covergroup):
+    NAME = "exception_handling"
+    DESCRIPTION = "Exception handling details"
+
+    def setup(self, ctx):
+        self.add_coverpoint(ExceptionContext())  # Large: ~900 buckets
+        self.add_covergroup(ExceptionRecovery())  # Level 3 nested
+
+
+# Level 3: Exception recovery
+class ExceptionRecovery(Covergroup):
+    NAME = "exception_recovery"
+    DESCRIPTION = "Exception recovery coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(RecoveryPaths())  # Medium: ~300 buckets
+
+
+# Small coverpoint: ~100 buckets (3 axes: 5, 4, 5 values)
+class ExceptionTypes(Coverpoint):
+    NAME = "exception_types"
+    DESCRIPTION = "Exception type coverage"
+    TIER = 1
+    TAGS = ["exception", "error"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="exception_type",
+            values=ctx.riscv_data.exception_types,
+            description="Exception type",
+        )
+        self.add_axis(
+            name="privilege",
+            values=ctx.riscv_data.privilege_levels,
+            description="Privilege level",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="instruction_type",
+            values=ctx.riscv_data.instruction_types[:5],
+            description="Instruction type",
+            enable_other="Other",
+        )
+
+        # Add target goal
+        self.add_goal("ILLEGAL_INSTR", "Illegal instructions need coverage", target=80)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.exception_type.name == "illegal_instruction":
+            return goals.ILLEGAL_INSTR
+
+    def should_sample(self, trace):
+        return trace.exception_type not in (None, "none")
+
+    def sample(self, trace):
+        self.bucket.clear()
+        self.bucket.set_axes(
+            exception_type=trace.exception_type,
+            privilege=trace.privilege_level if trace.privilege_level else "user",
+            instruction_type=trace.instruction_type
+            if trace.instruction_type
+            else "ADD",
+        )
+        self.bucket.hit()
+
+
+# Large coverpoint: ~900 buckets (5 axes: 5, 4, 5, 3, 3 values)
+class ExceptionContext(Coverpoint):
+    NAME = "exception_context"
+    DESCRIPTION = "Exception context coverage"
+    TIER = 3
+    TAGS = ["exception", "context"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="exception_type",
+            values=ctx.riscv_data.exception_types,
+            description="Exception type",
+        )
+        self.add_axis(
+            name="privilege",
+            values=ctx.riscv_data.privilege_levels,
+            description="Privilege level",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="pipeline_stage",
+            values=ctx.riscv_data.pipeline_stages[:5],
+            description="Pipeline stage",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="execution_state",
+            values=ctx.riscv_data.execution_states[:3],
+            description="Execution state",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="instruction_type",
+            values=ctx.riscv_data.instruction_types[:3],
+            description="Instruction type",
+            enable_other="Other",
+        )
+
+        # Add ignore goal for invalid exception state (not interesting)
+        self.add_goal(
+            "INVALID_EXCEPTION", "Invalid exception state combination", ignore=True
+        )
+
+    def apply_goals(self, bucket, goals):
+        if (
+            bucket.exception_type.name == "none"
+            and bucket.execution_state.name == "exception"
+        ):
+            return goals.INVALID_EXCEPTION
+
+    def sample(self, trace):
+        self.bucket.clear()
+        self.bucket.set_axes(
+            exception_type=trace.exception_type,
+            privilege=trace.privilege_level if trace.privilege_level else "user",
+            pipeline_stage=str(trace.pipeline_stage)
+            if trace.pipeline_stage is not None and trace.pipeline_stage < 5
+            else "Other",
+            execution_state=trace.execution_state if trace.execution_state else "idle",
+            instruction_type=trace.instruction_type
+            if trace.instruction_type
+            else "ADD",
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~300 buckets (4 axes: 5, 4, 5, 3 values)
+class RecoveryPaths(Coverpoint):
+    NAME = "recovery_paths"
+    DESCRIPTION = "Exception recovery path coverage"
+    TIER = 2
+    TAGS = ["exception", "recovery"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="exception_type",
+            values=ctx.riscv_data.exception_types,
+            description="Exception type",
+        )
+        self.add_axis(
+            name="recovery_type",
+            values=["retry", "skip", "handler", "abort"],
+            description="Recovery type",
+        )
+        self.add_axis(
+            name="privilege",
+            values=ctx.riscv_data.privilege_levels,
+            description="Privilege level",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="pipeline_stage",
+            values=ctx.riscv_data.pipeline_stages[:3],
+            description="Pipeline stage",
+            enable_other="Other",
+        )
+
+        # Add target goal
+        self.add_goal(
+            "HANDLER_RECOVERY", "Handler recovery needs more coverage", target=200
+        )
+
+    def apply_goals(self, bucket, goals):
+        if bucket.recovery_type.name == "handler":
+            return goals.HANDLER_RECOVERY
+
+    def should_sample(self, trace):
+        return trace.exception_type not in (None, "none")
+
+    def sample(self, trace):
+        recovery_type = "handler" if trace.exception_type != "none" else "skip"
+        self.bucket.clear()
+        self.bucket.set_axes(
+            exception_type=trace.exception_type,
+            recovery_type=recovery_type,
+            privilege=trace.privilege_level if trace.privilege_level else "user",
+            pipeline_stage=str(trace.pipeline_stage)
+            if trace.pipeline_stage is not None and trace.pipeline_stage < 5
+            else "Other",
+        )
+        self.bucket.hit()

--- a/examples/riscv_stress/stress_modules/module_04.py
+++ b/examples/riscv_stress/stress_modules/module_04.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from bucket import AxisUtils, Covergroup, Coverpoint
+
+
+# Level 1: Register file
+class RegisterFileGroup(Covergroup):
+    NAME = "register_file"
+    DESCRIPTION = "Register file coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(RegisterAccess())  # Small: ~180 buckets
+        self.add_covergroup(RegisterHazards())  # Nested group
+        self.add_coverpoint(RegisterWriteback())  # Medium: ~420 buckets
+
+
+# Level 2: Register hazards
+class RegisterHazards(Covergroup):
+    NAME = "register_hazards"
+    DESCRIPTION = "Register hazard coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(RegisterDependencies())  # Large: ~1200 buckets
+
+
+# Small coverpoint: ~180 buckets (3 axes: 6, 5, 6 values)
+class RegisterAccess(Coverpoint):
+    NAME = "register_access"
+    DESCRIPTION = "Register access coverage"
+    TIER = 1
+    TAGS = ["register", "access"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="register",
+            values=ctx.riscv_data.registers[:6],
+            description="Register accessed",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="access_type",
+            values=["read", "write", "read_write"],
+            description="Access type",
+        )
+        self.add_axis(
+            name="instruction_type",
+            values=ctx.riscv_data.instruction_types[:6],
+            description="Instruction type",
+            enable_other="Other",
+        )
+
+        # Add target goal
+        self.add_goal("X0_ACCESS", "x0 access is special", target=50)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.register.name == "x0":
+            return goals.X0_ACCESS
+
+    def sample(self, trace):
+        access_type = "read"
+        if trace.rd:
+            if trace.rs1 or trace.rs2:
+                access_type = "read_write"
+            else:
+                access_type = "write"
+        elif trace.rs1 or trace.rs2:
+            access_type = "read"
+        reg = trace.rd if trace.rd else (trace.rs1 if trace.rs1 else "x0")
+        self.bucket.clear()
+        self.bucket.set_axes(
+            register=reg,
+            access_type=access_type,
+            instruction_type=trace.instruction_type
+            if trace.instruction_type
+            else "ADD",
+        )
+        self.bucket.hit()
+
+
+# Large coverpoint: ~1200 buckets (5 axes: 5, 4, 5, 4, 3 values)
+class RegisterDependencies(Coverpoint):
+    NAME = "register_dependencies"
+    DESCRIPTION = "Register dependency coverage"
+    TIER = 3
+    TAGS = ["register", "dependencies"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:5],
+            description="Destination register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:4],
+            description="Source register 1",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs2",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 2",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="dependency_type",
+            values=["RAW", "WAR", "WAW", "none"],
+            description="Dependency type",
+        )
+        self.add_axis(
+            name="stall_cycles",
+            values=AxisUtils.msb(2, include_max=True),
+            description="Stall cycles (MSB)",
+        )
+
+        # Add target goal
+        self.add_goal("RAW_DEP", "RAW dependencies need more coverage", target=600)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.dependency_type.name == "RAW":
+            return goals.RAW_DEP
+
+    def sample(self, trace):
+        dependency_type = "none"
+        if trace.rd and trace.rs1 and trace.rd == trace.rs1:
+            dependency_type = "RAW"
+        elif trace.rd and trace.rs2 and trace.rd == trace.rs2:
+            dependency_type = "RAW"
+        stall_cycles = 1 if dependency_type != "none" else 0
+        self.bucket.clear()
+        self.bucket.set_axes(
+            rd=trace.rd if trace.rd else "x0",
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            rs2=trace.rs2 if trace.rs2 else "x0",
+            dependency_type=dependency_type,
+            stall_cycles=stall_cycles,
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~420 buckets (4 axes: 5, 4, 5, 3 values)
+class RegisterWriteback(Coverpoint):
+    NAME = "register_writeback"
+    DESCRIPTION = "Register writeback coverage"
+    TIER = 2
+    TAGS = ["register", "writeback"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:5],
+            description="Destination register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="writeback_stage",
+            values=ctx.riscv_data.pipeline_stages[:4],
+            description="Writeback stage",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="instruction_type",
+            values=ctx.riscv_data.instruction_types[:5],
+            description="Instruction type",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="data_size",
+            values=ctx.riscv_data.data_sizes[:3],
+            description="Data size",
+            enable_other="Other",
+        )
+
+        # Add ignore goal
+        self.add_goal("IGNORE_X0", "Ignore writeback to x0", ignore=True)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.rd.name == "x0":
+            return goals.IGNORE_X0
+
+    def should_sample(self, trace):
+        return bool(trace.rd)
+
+    def sample(self, trace):
+        self.bucket.clear()
+        self.bucket.set_axes(
+            rd=trace.rd,
+            writeback_stage=str(
+                trace.pipeline_stage
+                if trace.pipeline_stage is not None and trace.pipeline_stage < 4
+                else "Other"
+            ),
+            instruction_type=trace.instruction_type
+            if trace.instruction_type
+            else "ADD",
+            data_size=trace.data_size if trace.data_size else 32,
+        )
+        self.bucket.hit()

--- a/examples/riscv_stress/stress_modules/module_05.py
+++ b/examples/riscv_stress/stress_modules/module_05.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from bucket import AxisUtils, Covergroup, Coverpoint
+
+
+# Level 1: Control flow
+class ControlFlowGroup(Covergroup):
+    NAME = "control_flow"
+    DESCRIPTION = "Control flow coverage"
+
+    def should_sample(self, trace):
+        return (
+            trace.category in ("Jump", "Branch")
+            or trace.format_type == "B-type"
+            or trace.branch_outcome is not None
+        )
+
+    def setup(self, ctx):
+        self.add_coverpoint(JumpOperations())  # Small: ~90 buckets
+        self.add_covergroup(BranchControl())  # Nested group
+
+
+# Level 2: Branch control
+class BranchControl(Covergroup):
+    NAME = "branch_control"
+    DESCRIPTION = "Branch control coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(BranchTargets())  # Large: ~1100 buckets
+        self.add_covergroup(BranchPrediction())  # Level 3 nested
+
+
+# Level 3: Branch prediction
+class BranchPrediction(Covergroup):
+    NAME = "branch_prediction"
+    DESCRIPTION = "Branch prediction details"
+
+    def setup(self, ctx):
+        self.add_coverpoint(PredictionAccuracy())  # Medium: ~380 buckets
+
+
+# Small coverpoint: ~90 buckets (3 axes: 3, 5, 6 values)
+class JumpOperations(Coverpoint):
+    NAME = "jump_operations"
+    DESCRIPTION = "Jump operation coverage"
+    TIER = 1
+    TAGS = ["jump", "control-flow"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="jump_type",
+            values=["JAL", "JALR"],
+            description="Jump instruction type",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:5],
+            description="Return address register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="target",
+            values=AxisUtils.ranges(1023, 6, min_val=0),
+            description="Jump target ranges",
+        )
+
+        # Add target goal
+        self.add_goal("JAL_JUMP", "JAL jumps are common", target=60)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.jump_type.name == "JAL":
+            return goals.JAL_JUMP
+
+    def should_sample(self, trace):
+        return trace.category == "Jump"
+
+    def sample(self, trace):
+        jump_type = trace.instruction_type if trace.instruction_type else "JAL"
+        if jump_type not in ["JAL", "JALR"]:
+            jump_type = "Other"
+        self.bucket.clear()
+        self.bucket.set_axes(
+            jump_type=jump_type,
+            rd=trace.rd if trace.rd else "x1",
+            target=(trace.immediate if trace.immediate is not None else 0) % 1024,
+        )
+        self.bucket.hit()
+
+
+# Large coverpoint: ~1100 buckets (5 axes: 4, 5, 5, 4, 2 values)
+class BranchTargets(Coverpoint):
+    NAME = "branch_targets"
+    DESCRIPTION = "Branch target coverage"
+    TIER = 3
+    TAGS = ["branch", "targets"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="branch_type",
+            values=["BEQ", "BNE", "BLT", "BGE"],
+            description="Branch type",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 1",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs2",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 2",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="target_offset",
+            values=AxisUtils.ranges(
+                2047, 4, min_val=-1024, separate_min=True, separate_max=True
+            ),
+            description="Branch target offset",
+        )
+        self.add_axis(
+            name="taken",
+            values=AxisUtils.polarity(),
+            description="Branch taken (polarity)",
+        )
+
+        # Add target goal
+        self.add_goal("FAR_BRANCH", "Far branches need more coverage", target=550)
+
+    def apply_goals(self, bucket, goals):
+        if "1023" in bucket.target_offset.name or "-1024" in bucket.target_offset.name:
+            return goals.FAR_BRANCH
+
+    def should_sample(self, trace):
+        if trace.format_type != "B-type":
+            return False
+        branch_type = trace.instruction_type if trace.instruction_type else "BEQ"
+        return branch_type in ["BEQ", "BNE", "BLT", "BGE"]
+
+    def sample(self, trace):
+        branch_type = trace.instruction_type if trace.instruction_type else "BEQ"
+        taken = 1 if trace.branch_outcome == "taken" else 0
+        offset = trace.immediate if trace.immediate is not None else 0
+        # Clamp to range
+        if offset > 1023:
+            offset = 1023
+        elif offset < -1024:
+            offset = -1024
+        self.bucket.clear()
+        self.bucket.set_axes(
+            branch_type=branch_type,
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            rs2=trace.rs2 if trace.rs2 else "x0",
+            target_offset=offset,
+            taken=taken,
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~380 buckets (4 axes: 4, 5, 5, 3 values)
+class PredictionAccuracy(Coverpoint):
+    NAME = "prediction_accuracy"
+    DESCRIPTION = "Branch prediction accuracy coverage"
+    TIER = 2
+    TAGS = ["branch", "prediction"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="prediction",
+            values=["taken", "not_taken"],
+            description="Prediction",
+        )
+        self.add_axis(
+            name="actual",
+            values=["taken", "not_taken"],
+            description="Actual outcome",
+        )
+        self.add_axis(
+            name="branch_type",
+            values=ctx.riscv_data.instruction_types[:5],
+            description="Branch type",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="confidence",
+            values=["high", "medium", "low"],
+            description="Prediction confidence",
+        )
+
+        # Add target goal for prediction accuracy (needs more coverage)
+        self.add_goal(
+            "PREDICTION_ACCURACY", "Prediction accuracy needs more coverage", target=400
+        )
+
+    def apply_goals(self, bucket, goals):
+        # Apply goal for mispredicted branches
+        if bucket.prediction.name != bucket.actual.name:
+            return goals.PREDICTION_ACCURACY
+
+    def should_sample(self, trace):
+        return trace.branch_outcome is not None
+
+    def sample(self, trace):
+        prediction = (
+            "taken"
+            if trace.branch_outcome in ["taken", "mispredicted"]
+            else "not_taken"
+        )
+        actual = "taken" if trace.branch_outcome == "taken" else "not_taken"
+        confidence = "high" if trace.branch_outcome != "mispredicted" else "low"
+        self.bucket.clear()
+        self.bucket.set_axes(
+            prediction=prediction,
+            actual=actual,
+            branch_type=trace.instruction_type if trace.instruction_type else "BEQ",
+            confidence=confidence,
+        )
+        self.bucket.hit()

--- a/examples/riscv_stress/stress_modules/module_06.py
+++ b/examples/riscv_stress/stress_modules/module_06.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from bucket import AxisUtils, Covergroup, Coverpoint
+
+
+# Level 1: Arithmetic operations
+class ArithmeticGroup(Covergroup):
+    NAME = "arithmetic"
+    DESCRIPTION = "Arithmetic operation coverage"
+
+    def should_sample(self, trace):
+        return trace.category == "Arithmetic"
+
+    def setup(self, ctx):
+        self.add_coverpoint(BasicArithmetic())  # Small: ~140 buckets
+        self.add_covergroup(AdvancedArithmetic())  # Nested group
+
+
+# Level 2: Advanced arithmetic
+class AdvancedArithmetic(Covergroup):
+    NAME = "advanced_arithmetic"
+    DESCRIPTION = "Advanced arithmetic coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(ArithmeticOverflow())  # Large: ~850 buckets
+        self.add_coverpoint(ArithmeticFlags())  # Medium: ~360 buckets
+
+
+# Small coverpoint: ~140 buckets (3 axes: 4, 5, 7 values)
+class BasicArithmetic(Coverpoint):
+    NAME = "basic_arithmetic"
+    DESCRIPTION = "Basic arithmetic operations"
+    TIER = 1
+    TAGS = ["arithmetic", "basic"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="operation",
+            values=["ADD", "SUB", "MUL", "DIV"],
+            description="Arithmetic operation",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:5],
+            description="Destination register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="operand_range",
+            values=AxisUtils.ranges(63, 7, min_val=0),
+            description="Operand value ranges",
+        )
+
+        # Add target goal
+        self.add_goal("ADD_OP", "ADD operations are common", target=70)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.operation.name == "ADD":
+            return goals.ADD_OP
+
+    def should_sample(self, trace):
+        operation = trace.instruction_type if trace.instruction_type else "ADD"
+        return operation in ["ADD", "SUB", "MUL", "DIV"]
+
+    def sample(self, trace):
+        operation = trace.instruction_type if trace.instruction_type else "ADD"
+        operand = trace.immediate if trace.immediate is not None else 0
+        self.bucket.clear()
+        self.bucket.set_axes(
+            operation=operation,
+            rd=trace.rd if trace.rd else "x0",
+            operand_range=operand % 64,
+        )
+        self.bucket.hit()
+
+
+# Large coverpoint: ~850 buckets (5 axes: 4, 5, 5, 4, 2 values)
+class ArithmeticOverflow(Coverpoint):
+    NAME = "arithmetic_overflow"
+    DESCRIPTION = "Arithmetic overflow coverage"
+    TIER = 3
+    TAGS = ["arithmetic", "overflow"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="operation",
+            values=["ADD", "SUB", "MUL"],
+            description="Arithmetic operation",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 1",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs2",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 2",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="overflow",
+            values=AxisUtils.one_hot(2, include_zero=True),
+            description="Overflow flag (one-hot)",
+        )
+        self.add_axis(
+            name="sign",
+            values=AxisUtils.polarity(),
+            description="Result sign (polarity)",
+        )
+
+        # Add target goal
+        self.add_goal("OVERFLOW_CASE", "Overflow cases need more coverage", target=425)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.overflow.name != "0b0":
+            return goals.OVERFLOW_CASE
+
+    def sample(self, trace):
+        operation = trace.instruction_type if trace.instruction_type else "ADD"
+        if operation not in ["ADD", "SUB", "MUL"]:
+            operation = "Other"
+        # Simulate overflow detection
+        overflow = 0  # Would be calculated in real implementation
+        sign = 0  # Would be calculated in real implementation
+        self.bucket.clear()
+        self.bucket.set_axes(
+            operation=operation,
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            rs2=trace.rs2 if trace.rs2 else "x0",
+            overflow=overflow,
+            sign=sign,
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~360 buckets (4 axes: 5, 4, 5, 3 values)
+class ArithmeticFlags(Coverpoint):
+    NAME = "arithmetic_flags"
+    DESCRIPTION = "Arithmetic flag coverage"
+    TIER = 2
+    TAGS = ["arithmetic", "flags"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="operation",
+            values=ctx.riscv_data.instruction_types[:5],
+            description="Arithmetic operation",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="zero_flag",
+            values=AxisUtils.enabled(),
+            description="Zero flag",
+        )
+        self.add_axis(
+            name="negative_flag",
+            values=AxisUtils.polarity(),
+            description="Negative flag",
+        )
+        self.add_axis(
+            name="carry_flag",
+            values=AxisUtils.enabled(),
+            description="Carry flag",
+        )
+
+        # Add ignore goal
+        self.add_goal("IGNORE_NO_FLAGS", "Ignore cases with no flags", ignore=True)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.zero_flag.name == "Disabled" and bucket.carry_flag.name == "Disabled":
+            return goals.IGNORE_NO_FLAGS
+
+    def sample(self, trace):
+        # Simulate flag generation
+        zero_flag = 1 if trace.immediate == 0 else 0
+        negative_flag = 1 if trace.immediate and trace.immediate < 0 else 0
+        carry_flag = 0  # Would be calculated in real implementation
+        self.bucket.clear()
+        self.bucket.set_axes(
+            operation=trace.instruction_type if trace.instruction_type else "ADD",
+            zero_flag=zero_flag,
+            negative_flag=negative_flag,
+            carry_flag=carry_flag,
+        )
+        self.bucket.hit()

--- a/examples/riscv_stress/stress_modules/module_07.py
+++ b/examples/riscv_stress/stress_modules/module_07.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from bucket import AxisUtils, Covergroup, Coverpoint
+
+
+# Level 1: Logical operations
+class LogicalGroup(Covergroup):
+    NAME = "logical"
+    DESCRIPTION = "Logical operation coverage"
+
+    def should_sample(self, trace):
+        return trace.category in ("Logical", "Shift")
+
+    def setup(self, ctx):
+        self.add_coverpoint(BasicLogical())  # Small: ~110 buckets
+        self.add_covergroup(LogicalAdvanced())  # Nested group
+
+
+# Level 2: Advanced logical
+class LogicalAdvanced(Covergroup):
+    NAME = "logical_advanced"
+    DESCRIPTION = "Advanced logical coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(BitwiseOperations())  # Large: ~950 buckets
+        self.add_covergroup(LogicalShifts())  # Level 3 nested
+
+
+# Level 3: Logical shifts
+class LogicalShifts(Covergroup):
+    NAME = "logical_shifts"
+    DESCRIPTION = "Logical shift coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(ShiftOperations())  # Medium: ~340 buckets
+
+
+# Small coverpoint: ~110 buckets (3 axes: 3, 5, 7 values)
+class BasicLogical(Coverpoint):
+    NAME = "basic_logical"
+    DESCRIPTION = "Basic logical operations"
+    TIER = 1
+    TAGS = ["logical", "basic"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="operation",
+            values=["AND", "OR", "XOR"],
+            description="Logical operation",
+        )
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:5],
+            description="Destination register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="mask",
+            values=AxisUtils.ranges(31, 7, min_val=0),
+            description="Mask value ranges",
+        )
+
+        # Add target goal
+        self.add_goal("AND_OP", "AND operations are common", target=55)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.operation.name == "AND":
+            return goals.AND_OP
+
+    def should_sample(self, trace):
+        if trace.category != "Logical":
+            return False
+        operation = trace.instruction_type if trace.instruction_type else "AND"
+        return operation in ["AND", "OR", "XOR"]
+
+    def sample(self, trace):
+        operation = trace.instruction_type if trace.instruction_type else "AND"
+        mask = trace.immediate if trace.immediate is not None else 0
+        self.bucket.clear()
+        self.bucket.set_axes(
+            operation=operation,
+            rd=trace.rd if trace.rd else "x0",
+            mask=mask % 32,
+        )
+        self.bucket.hit()
+
+
+# Large coverpoint: ~950 buckets (5 axes: 4, 5, 5, 4, 2 values)
+class BitwiseOperations(Coverpoint):
+    NAME = "bitwise_operations"
+    DESCRIPTION = "Bitwise operation coverage"
+    TIER = 3
+    TAGS = ["logical", "bitwise"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="operation",
+            values=["AND", "OR", "XOR", "NOT"],
+            description="Bitwise operation",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 1",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs2",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 2",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="bit_position",
+            values=AxisUtils.one_hot(4, include_zero=True),
+            description="Bit position (one-hot)",
+        )
+        self.add_axis(
+            name="result_bit",
+            values=AxisUtils.enabled(),
+            description="Result bit value",
+        )
+
+        # Add target goal
+        self.add_goal("XOR_OP", "XOR operations need more coverage", target=475)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.operation.name == "XOR":
+            return goals.XOR_OP
+
+    def should_sample(self, trace):
+        if trace.category != "Logical":
+            return False
+        operation = trace.instruction_type if trace.instruction_type else "AND"
+        return operation in ["AND", "OR", "XOR", "NOT"]
+
+    def sample(self, trace):
+        operation = trace.instruction_type if trace.instruction_type else "AND"
+        bit_pos = (trace.immediate if trace.immediate is not None else 0) % 16
+        result_bit = 1 if bit_pos % 2 == 0 else 0
+        self.bucket.clear()
+        self.bucket.set_axes(
+            operation=operation,
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            rs2=trace.rs2 if trace.rs2 else "x0",
+            bit_position=1 << (bit_pos % 4) if bit_pos < 4 else 0,
+            result_bit=result_bit,
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~340 buckets (4 axes: 4, 5, 5, 3 values)
+class ShiftOperations(Coverpoint):
+    NAME = "shift_operations"
+    DESCRIPTION = "Shift operation coverage"
+    TIER = 2
+    TAGS = ["logical", "shift"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="shift_type",
+            values=["SLL", "SRL", "SRA"],
+            description="Shift type",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:5],
+            description="Destination register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="shift_amount",
+            values=AxisUtils.ranges(31, 3, min_val=0),
+            description="Shift amount ranges",
+            enable_other="Other",
+        )
+
+        # Add target goal for large shift amounts (needs more coverage)
+        self.add_goal(
+            "LARGE_SHIFT_AMOUNT", "Large shift amounts need more coverage", target=350
+        )
+
+    def apply_goals(self, bucket, goals):
+        # Apply goal for shift amounts in the highest range
+        if (
+            "28 -> 31" in bucket.shift_amount.name
+            or "30 -> 31" in bucket.shift_amount.name
+        ):
+            return goals.LARGE_SHIFT_AMOUNT
+
+    def should_sample(self, trace):
+        return trace.category == "Shift"
+
+    def sample(self, trace):
+        shift_type = trace.instruction_type if trace.instruction_type else "SLL"
+        if shift_type not in ["SLL", "SRL", "SRA"]:
+            shift_type = "Other"
+        shift_amount = trace.immediate if trace.immediate is not None else 0
+        # Values outside [0, 31] will be caught by enable_other automatically
+        # Clamp > 31 to 31 to stay in range
+        if shift_amount > 31:
+            shift_amount = 31
+        # Negative values will be handled by enable_other
+        self.bucket.clear()
+        self.bucket.set_axes(
+            shift_type=shift_type,
+            rd=trace.rd if trace.rd else "x0",
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            shift_amount=shift_amount,
+        )
+        self.bucket.hit()

--- a/examples/riscv_stress/stress_modules/module_08.py
+++ b/examples/riscv_stress/stress_modules/module_08.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from bucket import AxisUtils, Covergroup, Coverpoint
+
+
+# Level 1: System operations
+class SystemGroup(Covergroup):
+    NAME = "system"
+    DESCRIPTION = "System operation coverage"
+
+    def should_sample(self, trace):
+        return (
+            trace.csr is not None
+            or trace.privilege_level is not None
+            or trace.exception_type == "timer_interrupt"
+        )
+
+    def setup(self, ctx):
+        self.add_coverpoint(CSROperations())  # Small: ~130 buckets
+        self.add_covergroup(SystemAdvanced())  # Nested group
+
+
+# Level 2: Advanced system
+class SystemAdvanced(Covergroup):
+    NAME = "system_advanced"
+    DESCRIPTION = "Advanced system coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(PrivilegeTransitions())  # Large: ~800 buckets
+        self.add_coverpoint(InterruptHandling())  # Medium: ~290 buckets
+
+
+# Small coverpoint: ~130 buckets (3 axes: 4, 5, 6 values)
+class CSROperations(Coverpoint):
+    NAME = "csr_operations"
+    DESCRIPTION = "CSR operation coverage"
+    TIER = 1
+    TAGS = ["system", "csr"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="csr_op",
+            values=["CSRRW", "CSRRS", "CSRRC", "CSRRWI"],
+            description="CSR operation",
+        )
+        self.add_axis(
+            name="csr",
+            values=ctx.riscv_data.csr_registers[:5],
+            description="CSR register",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rd",
+            values=ctx.riscv_data.registers[:6],
+            description="Destination register",
+            enable_other="Other",
+        )
+
+        # Add target goal
+        self.add_goal("CSR_READ", "CSR reads are common", target=65)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.csr_op.name in ["CSRRS", "CSRRC"]:
+            return goals.CSR_READ
+
+    def should_sample(self, trace):
+        return trace.csr is not None
+
+    def sample(self, trace):
+        csr_op = "CSRRW"  # Default
+        self.bucket.clear()
+        self.bucket.set_axes(
+            csr_op=csr_op,
+            csr=trace.csr,
+            rd=trace.rd if trace.rd else "x0",
+        )
+        self.bucket.hit()
+
+
+# Large coverpoint: ~800 buckets (5 axes: 4, 5, 4, 4, 2 values)
+class PrivilegeTransitions(Coverpoint):
+    NAME = "privilege_transitions"
+    DESCRIPTION = "Privilege transition coverage"
+    TIER = 3
+    TAGS = ["system", "privilege"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="from_privilege",
+            values=ctx.riscv_data.privilege_levels,
+            description="Source privilege level",
+        )
+        self.add_axis(
+            name="to_privilege",
+            values=ctx.riscv_data.privilege_levels,
+            description="Destination privilege level",
+        )
+        self.add_axis(
+            name="transition_type",
+            values=["ecall", "mret", "sret", "exception"],
+            description="Transition type",
+        )
+        self.add_axis(
+            name="pipeline_stage",
+            values=ctx.riscv_data.pipeline_stages[:4],
+            description="Pipeline stage",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="allowed",
+            values=AxisUtils.enabled(),
+            description="Transition allowed",
+        )
+
+        # Add target goal for privilege transitions (needs more coverage)
+        self.add_goal(
+            "PRIVILEGE_TRANS", "Privilege transitions need more coverage", target=450
+        )
+
+    def apply_goals(self, bucket, goals):
+        # Apply goal for user to machine transitions (should be rare)
+        if (
+            bucket.from_privilege.name == "user"
+            and bucket.to_privilege.name == "machine"
+        ):
+            return goals.PRIVILEGE_TRANS
+
+    def should_sample(self, trace):
+        return trace.privilege_level is not None
+
+    def sample(self, trace):
+        from_priv = trace.privilege_level
+        to_priv = "supervisor" if trace.exception_type != "none" else from_priv
+        transition_type = "exception" if trace.exception_type != "none" else "ecall"
+        allowed = 1 if (from_priv != "user" or to_priv != "machine") else 0
+        self.bucket.clear()
+        self.bucket.set_axes(
+            from_privilege=from_priv,
+            to_privilege=to_priv,
+            transition_type=transition_type,
+            pipeline_stage=str(trace.pipeline_stage)
+            if trace.pipeline_stage is not None and trace.pipeline_stage < 5
+            else "Other",
+            allowed=allowed,
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~290 buckets (4 axes: 3, 5, 5, 3 values)
+class InterruptHandling(Coverpoint):
+    NAME = "interrupt_handling"
+    DESCRIPTION = "Interrupt handling coverage"
+    TIER = 2
+    TAGS = ["system", "interrupt"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="interrupt_type",
+            values=["timer", "external", "software"],
+            description="Interrupt type",
+        )
+        self.add_axis(
+            name="privilege",
+            values=ctx.riscv_data.privilege_levels,
+            description="Privilege level",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="pipeline_stage",
+            values=ctx.riscv_data.pipeline_stages[:5],
+            description="Pipeline stage",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="masked",
+            values=AxisUtils.enabled(),
+            description="Interrupt masked",
+        )
+
+        # Add target goal
+        self.add_goal("TIMER_INT", "Timer interrupts need more coverage", target=145)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.interrupt_type.name == "timer":
+            return goals.TIMER_INT
+
+    def should_sample(self, trace):
+        return trace.exception_type == "timer_interrupt"
+
+    def sample(self, trace):
+        interrupt_type = (
+            "timer" if trace.exception_type == "timer_interrupt" else "external"
+        )
+        masked = 0  # Would be determined by interrupt mask in real implementation
+        self.bucket.clear()
+        self.bucket.set_axes(
+            interrupt_type=interrupt_type,
+            privilege=trace.privilege_level if trace.privilege_level else "user",
+            pipeline_stage=str(trace.pipeline_stage)
+            if trace.pipeline_stage is not None and trace.pipeline_stage < 5
+            else "Other",
+            masked=masked,
+        )
+        self.bucket.hit()

--- a/examples/riscv_stress/stress_modules/module_09.py
+++ b/examples/riscv_stress/stress_modules/module_09.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from bucket import AxisUtils, Covergroup, Coverpoint
+
+
+# Level 1: Compare operations
+class CompareGroup(Covergroup):
+    NAME = "compare"
+    DESCRIPTION = "Compare operation coverage"
+
+    def should_sample(self, trace):
+        return trace.category == "Compare"
+
+    def setup(self, ctx):
+        self.add_coverpoint(CompareOperations())  # Small: ~160 buckets
+        self.add_covergroup(CompareAdvanced())  # Nested group
+
+
+# Level 2: Advanced compare
+class CompareAdvanced(Covergroup):
+    NAME = "compare_advanced"
+    DESCRIPTION = "Advanced compare coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(CompareResults())  # Large: ~700 buckets
+        self.add_covergroup(CompareFlags())  # Level 3 nested
+
+
+# Level 3: Compare flags
+class CompareFlags(Covergroup):
+    NAME = "compare_flags"
+    DESCRIPTION = "Compare flag coverage"
+
+    def setup(self, ctx):
+        self.add_coverpoint(FlagGeneration())  # Medium: ~270 buckets
+
+
+# Small coverpoint: ~160 buckets (3 axes: 4, 5, 8 values)
+class CompareOperations(Coverpoint):
+    NAME = "compare_operations"
+    DESCRIPTION = "Compare operation coverage"
+    TIER = 1
+    TAGS = ["compare", "basic"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="compare_type",
+            values=["SLT", "SLTU", "EQ", "NE"],
+            description="Compare type",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 1",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="operand_range",
+            values=AxisUtils.ranges(
+                127, 8, min_val=-64, separate_min=True, separate_max=True
+            ),
+            description="Operand value ranges",
+        )
+
+        # Add target goal
+        self.add_goal("SLT_COMPARE", "SLT compares are common", target=80)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.compare_type.name == "SLT":
+            return goals.SLT_COMPARE
+
+    def should_sample(self, trace):
+        compare_type = trace.instruction_type if trace.instruction_type else "SLT"
+        return compare_type in ["SLT", "SLTU", "EQ", "NE"]
+
+    def sample(self, trace):
+        compare_type = trace.instruction_type if trace.instruction_type else "SLT"
+        operand = trace.immediate if trace.immediate is not None else 0
+        # Clamp to range
+        if operand > 127:
+            operand = 127
+        elif operand < -64:
+            operand = -64
+        self.bucket.clear()
+        self.bucket.set_axes(
+            compare_type=compare_type,
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            operand_range=operand,
+        )
+        self.bucket.hit()
+
+
+# Large coverpoint: ~700 buckets (5 axes: 4, 5, 5, 4, 2 values)
+class CompareResults(Coverpoint):
+    NAME = "compare_results"
+    DESCRIPTION = "Compare result coverage"
+    TIER = 3
+    TAGS = ["compare", "results"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="compare_type",
+            values=["SLT", "SLTU", "EQ", "NE"],
+            description="Compare type",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs1",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 1",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="rs2",
+            values=ctx.riscv_data.registers[:5],
+            description="Source register 2",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="result",
+            values=AxisUtils.enabled(),
+            description="Compare result",
+        )
+        self.add_axis(
+            name="zero_result",
+            values=AxisUtils.polarity(),
+            description="Zero result (polarity)",
+        )
+
+        # Add target goal
+        self.add_goal("TRUE_RESULT", "True results need more coverage", target=350)
+
+    def apply_goals(self, bucket, goals):
+        if bucket.result.name == "Enabled":
+            return goals.TRUE_RESULT
+
+    def should_sample(self, trace):
+        compare_type = trace.instruction_type if trace.instruction_type else "SLT"
+        return compare_type in ["SLT", "SLTU", "EQ", "NE"]
+
+    def sample(self, trace):
+        compare_type = trace.instruction_type if trace.instruction_type else "SLT"
+        # Simulate compare result
+        result = 1  # Would be calculated in real implementation
+        zero_result = 0  # Would be calculated in real implementation
+        self.bucket.clear()
+        self.bucket.set_axes(
+            compare_type=compare_type,
+            rs1=trace.rs1 if trace.rs1 else "x0",
+            rs2=trace.rs2 if trace.rs2 else "x0",
+            result=result,
+            zero_result=zero_result,
+        )
+        self.bucket.hit()
+
+
+# Medium coverpoint: ~270 buckets (4 axes: 3, 5, 5, 3 values)
+class FlagGeneration(Coverpoint):
+    NAME = "flag_generation"
+    DESCRIPTION = "Flag generation coverage"
+    TIER = 2
+    TAGS = ["compare", "flags"]
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="compare_type",
+            values=["SLT", "SLTU", "EQ"],
+            description="Compare type",
+            enable_other="Other",
+        )
+        self.add_axis(
+            name="less_flag",
+            values=AxisUtils.enabled(),
+            description="Less than flag",
+        )
+        self.add_axis(
+            name="equal_flag",
+            values=AxisUtils.enabled(),
+            description="Equal flag",
+        )
+        self.add_axis(
+            name="greater_flag",
+            values=AxisUtils.enabled(),
+            description="Greater than flag",
+        )
+
+        # Add ignore goal
+        self.add_goal("IGNORE_NO_FLAGS", "Ignore cases with no flags set", ignore=True)
+
+    def apply_goals(self, bucket, goals):
+        if (
+            bucket.less_flag.name == "Disabled"
+            and bucket.equal_flag.name == "Disabled"
+            and bucket.greater_flag.name == "Disabled"
+        ):
+            return goals.IGNORE_NO_FLAGS
+
+    def should_sample(self, trace):
+        compare_type = trace.instruction_type if trace.instruction_type else "SLT"
+        return compare_type in ["SLT", "SLTU", "EQ"]
+
+    def sample(self, trace):
+        compare_type = trace.instruction_type if trace.instruction_type else "SLT"
+        # Simulate flag generation
+        less_flag = 1 if compare_type == "SLT" else 0
+        equal_flag = 1 if compare_type == "EQ" else 0
+        greater_flag = 0  # Would be calculated in real implementation
+        self.bucket.clear()
+        self.bucket.set_axes(
+            compare_type=compare_type,
+            less_flag=less_flag,
+            equal_flag=equal_flag,
+            greater_flag=greater_flag,
+        )
+        self.bucket.hit()

--- a/examples/riscv_stress/stress_top.py
+++ b/examples/riscv_stress/stress_top.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from bucket import Covertop
+
+from .stress_modules import (
+    module_00,
+    module_01,
+    module_02,
+    module_03,
+    module_04,
+    module_05,
+    module_06,
+    module_07,
+    module_08,
+    module_09,
+)
+
+_MODULE_FACTORIES = (
+    ("instruction_formats", module_00.InstructionFormatGroup),
+    ("memory_operations", module_01.MemoryGroup),
+    ("pipeline", module_02.PipelineGroup),
+    ("exceptions", module_03.ExceptionGroup),
+    ("register_file", module_04.RegisterFileGroup),
+    ("control_flow", module_05.ControlFlowGroup),
+    ("arithmetic", module_06.ArithmeticGroup),
+    ("logical", module_07.LogicalGroup),
+    ("system", module_08.SystemGroup),
+    ("compare", module_09.CompareGroup),
+)
+
+
+class StressTop(Covertop):
+    """
+    Top-level covertop containing all stress test coverage modules.
+
+    Pass copies > 1 to replicate the module set with unique names, which
+    scales the tree for sampling and merge stress tests.
+    """
+
+    NAME = "StressTest"
+    DESCRIPTION = (
+        "Large-scale stress test coverage with deep nesting and extensive features"
+    )
+
+    def __init__(self, copies: int = 1, **kwargs):
+        if copies < 1:
+            raise ValueError("copies must be >= 1")
+        self.copies = copies
+        super().__init__(**kwargs)
+
+    def setup(self, ctx):
+        for copy_idx in range(self.copies):
+            for module_name, factory in _MODULE_FACTORIES:
+                kwargs = {}
+                if self.copies > 1:
+                    kwargs["name"] = f"{module_name}_{copy_idx:02d}"
+                self.add_covergroup(factory(), **kwargs)

--- a/tests/test_riscv_stress.py
+++ b/tests/test_riscv_stress.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+import random
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from examples.riscv_stress.generate_stress_data import generate
+from examples.riscv_stress.stress_common import (
+    RISCVDataset,
+    build_coverage,
+    generate_trace,
+    tree_stats,
+)
+from examples.riscv_stress.stress_example import bench_sample, run
+
+
+def test_tree_builds_and_samples():
+    riscv_data = RISCVDataset()
+    cvg = build_coverage(riscv_data=riscv_data, source="unit_test")
+    stats = tree_stats(cvg)
+    assert stats["coverpoints"] > 20
+    assert stats["buckets"] > 5_000
+
+    rand = random.Random(0)
+    for _ in range(50):
+        cvg.sample(generate_trace(rand, riscv_data))
+
+
+def test_tree_copies_scale_coverpoints():
+    base = tree_stats(build_coverage(copies=1))
+    doubled = tree_stats(build_coverage(copies=2))
+    assert doubled["coverpoints"] == base["coverpoints"] * 2
+    assert doubled["buckets"] == base["buckets"] * 2
+
+
+def test_sample_bench_runs():
+    result = bench_sample(iters=32, warmup=8, copies=1, seed=1)
+    assert result["iters"] == 32
+    assert result["coverpoints"] > 0
+    assert result["buckets"] > 0
+    assert result["sample_seconds"] >= 0
+
+
+def test_run_export_and_merge():
+    with TemporaryDirectory() as tmpdir:
+        output = Path(tmpdir)
+        run(
+            output_dir=output,
+            num_tests=3,
+            seed=1,
+            export_formats=["archive"],
+            samples_per_test=20,
+        )
+        merged = output / "riscv_stress" / "riscv_stress_merged.bktgz"
+        assert merged.is_file()
+        assert (
+            len(
+                list(
+                    (output / "riscv_stress" / "test_outputs" / "archive").glob(
+                        "*.bktgz"
+                    )
+                )
+            )
+            == 3
+        )
+
+
+def test_generate_synthetic_and_merge():
+    with TemporaryDirectory() as tmpdir:
+        output = Path(tmpdir)
+        generate(
+            output_dir=output,
+            num_tests=3,
+            seed=1,
+            formats=["archive"],
+            copies=1,
+        )
+        merged = output / "riscv_stress" / "riscv_stress_merged.bktgz"
+        assert merged.is_file()


### PR DESCRIPTION
## Summary
- Resurrect the RISC-V stress coverage tree on current APIs (BucketVal `.name`/`.value`, `should_sample` subtree skips, public `merge_files()`).
- Add a sampling bench for large covertrees (`python -m examples.riscv_stress sample`), with `--copies` to replicate the module set.
- Keep merge-at-scale via real runs (`run`) and synthetic compatible records (`generate`).

The default tree is 36 coverpoints / ~22k buckets.

## Before / after #188

Same tree, traces, seed, and machine. Median of 3 rounds, 50k samples after 1k warmup. Before is `1e63943` with this example copied in; after is this branch (`e5602ac`, which includes #188).

`python -m examples.riscv_stress sample --iters 50000 --warmup 1000 --seed 42`

| copies | coverpoints | buckets | before µs/sample | after µs/sample | speedup |
| -- | -- | -- | -- | -- | -- |
| 1 | 36 | 21,987 | 23.42 | 21.39 | **1.09×** (~9%) |
| 2 | 72 | 43,974 | 45.13 | 42.14 | **1.07×** (~7%) |
| 4 | 144 | 87,948 | 91.32 | 84.96 | **1.08×** (~7%) |

This is a realistic tree: most covergroups skip via `should_sample`, so the gain is smaller than the synthetic 20-coverpoint microbench in #188 (~28%). The walk still scales roughly linearly with `--copies`.

## Test plan
- [ ] `uv run pytest tests/test_riscv_stress.py`
- [ ] `python -m examples.riscv_stress sample --iters 20000`
- [ ] `python -m examples.riscv_stress sample --iters 5000 --copies 2` (coverpoints and buckets should double; samples/sec should drop)
- [ ] `python -m examples.riscv_stress run --num-tests 3 --formats archive --samples-per-test 50`
- [ ] `python -m examples.riscv_stress generate --num-tests 20 --formats archive sql`
- [ ] Open a merged `.bktgz` in the viewer