### PR TITLE
[None] Publish only tagged x.y.z versions, and only once

### DIFF
--- a/.github/RELEASE_AUTOMATION.md
+++ b/.github/RELEASE_AUTOMATION.md
@@ -75,9 +75,12 @@ workflow*:
   [`.git_archival.txt`](../.git_archival.txt) is substituted by GitHub at
   archive time (via `.gitattributes` `export-subst`) and setuptools-scm
   reads it, so archives of tagged commits version correctly.
-- **Escape hatch**: set `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NOODLE_BUCKET=X.Y.Z`
-  for the Python package, or `BUCKET_VERSION=X.Y.Z` for viewer/Electron
-  builds, to force a version when no git metadata is available.
+- **Escape hatch**: set `SETUPTOOLS_SCM_PRETEND_VERSION=X.Y.Z` for the Python
+  package, or `BUCKET_VERSION=X.Y.Z` for viewer/Electron builds, to force a
+  version when no git metadata is available. The per-distribution form
+  (`SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NOODLE_BUCKET`) is silently ignored:
+  hatch-vcs does not pass the distribution name through to setuptools-scm,
+  so only the bare variable is honoured.
 
 ## Publishing to PyPI (one-time setup)
 
@@ -119,8 +122,8 @@ gate the first few times; leave it off if a dispatch to `pypi` should
 upload immediately.
 
 Optional: under **Deployment branches and tags** on both, restrict to
-tags matching `v*`. If you do that, skip step 4's "from `main`" dry run
-and use an existing `v*` tag instead.
+tags matching `v*`. Publishing only ever happens from a tag, so this
+costs nothing.
 
 ### 3. Pending trusted publisher (TestPyPI first)
 
@@ -146,17 +149,21 @@ https://pypi.org/manage/account/publishing/ with environment name
 
 ### 4. Prove the pipeline on TestPyPI
 
-Pick one:
+Only plain `X.Y.Z` versions are uploaded, so the dry run has to come from
+a tag. An untagged commit builds as `X.Y.Z.devN+gSHA`, and both indexes
+reject that local segment, so a run from `main` builds and verifies the
+artifacts but publishes nothing.
 
-**From `main` (no tag):** *Actions → Publish to PyPI → Run workflow*,
-workflow from `main`, target **testpypi**. The build uses a throwaway
-version `0.0.<run_number>.dev0` because a local `+gSHA` version is
-rejected by the index.
+The next `[Patch]`/`[Minor]`/`[Major]` merge cuts a tag and uploads that
+exact version to TestPyPI automatically. To rehearse without waiting for a
+merge, cut a tag by hand with **Tag Release On Merge** (see [Manual
+release](#manual-release-immediate-or-exact-version)) and let the tag push
+do the upload.
 
-**From a tag:** the next `[Patch]`/`[Minor]`/`[Major]` merge uploads that
-exact version to TestPyPI automatically. To retry, run the workflow
-against that tag with target **testpypi** (`skip-existing` is on, so a
-repeat of the same version is a no-op).
+Re-running is always safe. The workflow queries the target index first and
+skips the upload if that version is already there, so running *Actions →
+Publish to PyPI → Run workflow* against an already-published tag is a
+no-op rather than an error.
 
 Then install and smoke-test (dependencies still come from real PyPI):
 

--- a/.github/RELEASE_AUTOMATION.md
+++ b/.github/RELEASE_AUTOMATION.md
@@ -122,8 +122,9 @@ gate the first few times; leave it off if a dispatch to `pypi` should
 upload immediately.
 
 Optional: under **Deployment branches and tags** on both, restrict to
-tags matching `v*`. Publishing only ever happens from a tag, so this
-costs nothing.
+tags matching `v*`. Real publishing only ever happens from a tag, so this
+costs nothing afterwards — but add it *after* step 4, because the
+rehearsal there runs from `main` and the restriction would block it.
 
 ### 3. Pending trusted publisher (TestPyPI first)
 
@@ -149,21 +150,34 @@ https://pypi.org/manage/account/publishing/ with environment name
 
 ### 4. Prove the pipeline on TestPyPI
 
-Only plain `X.Y.Z` versions are uploaded, so the dry run has to come from
-a tag. An untagged commit builds as `X.Y.Z.devN+gSHA`, and both indexes
-reject that local segment, so a run from `main` builds and verifies the
-artifacts but publishes nothing.
+Only plain `X.Y.Z` versions are uploaded. An untagged commit builds as
+`X.Y.Z.devN+gSHA`, and both indexes reject that local segment, so an
+ordinary run from `main` builds and verifies the artifacts but publishes
+nothing. It reports which tag it *could* publish, and whether the index
+already has it.
 
-The next `[Patch]`/`[Minor]`/`[Major]` merge cuts a tag and uploads that
-exact version to TestPyPI automatically. To rehearse without waiting for a
-merge, cut a tag by hand with **Tag Release On Merge** (see [Manual
-release](#manual-release-immediate-or-exact-version)) and let the tag push
-do the upload.
+**Rehearsal (no tag needed).** *Actions → Publish to PyPI → Run workflow*,
+from `main`, target **testpypi**, and set **test_version** to something
+outside the real release line such as `0.0.1`. That builds and uploads
+that exact version, which is enough to prove the whole path: OIDC, the
+environment, the pending publisher, and the upload itself. The first
+successful upload is also what turns the pending publisher into a real
+TestPyPI project.
+
+`test_version` is rejected with `target=pypi`, so it cannot touch
+production. Delete the throwaway version from TestPyPI afterwards if you
+would rather not leave it there.
+
+Do not cut a throwaway `v*` tag for this. Tag pushes also trigger
+[`deploy-viewer.yml`](workflows/deploy-viewer.yml), so a fake tag would
+publish the viewer site as a side effect.
+
+**The real thing.** The next `[Patch]`/`[Minor]`/`[Major]` merge cuts a tag
+and uploads that exact version to TestPyPI automatically.
 
 Re-running is always safe. The workflow queries the target index first and
-skips the upload if that version is already there, so running *Actions →
-Publish to PyPI → Run workflow* against an already-published tag is a
-no-op rather than an error.
+skips the upload if that version is already there, so running the workflow
+against an already-published tag is a no-op rather than an error.
 
 Then install and smoke-test (dependencies still come from real PyPI):
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,7 +7,9 @@
 # as x.y.z.devN+gSHA, and the indexes reject local version segments, so those
 # runs build and verify but skip publishing. Re-running a tag is a no-op: the
 # target index is queried first and the upload is skipped if it already has
-# that version. Operator setup: .github/RELEASE_AUTOMATION.md.
+# that version. To rehearse the upload path without cutting a tag, dispatch
+# with target=testpypi and test_version=0.0.1.
+# Operator setup: .github/RELEASE_AUTOMATION.md.
 
 name: Publish to PyPI
 
@@ -23,6 +25,11 @@ on:
           - testpypi
           - pypi
         default: testpypi
+      test_version:
+        description: "TestPyPI rehearsal only. Build this exact x.y.z (e.g. 0.0.1) instead of the git-derived version, to prove the upload path without cutting a tag. Leave blank for normal runs."
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -56,6 +63,26 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+
+      - name: Apply the rehearsal version override
+        if: github.event_name == 'workflow_dispatch' && inputs.test_version != ''
+        env:
+          TEST_VERSION: ${{ inputs.test_version }}
+          TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          if [ "${TARGET}" != "testpypi" ]; then
+            echo "::error title=Rehearsal is TestPyPI-only::test_version cannot be combined with target=pypi."
+            exit 1
+          fi
+          if [[ ! "${TEST_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error title=Invalid test_version::Expected a plain x.y.z, got '${TEST_VERSION}'."
+            exit 1
+          fi
+          # hatch-vcs ignores SETUPTOOLS_SCM_PRETEND_VERSION_FOR_<NAME>; only
+          # the bare variable has any effect.
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=${TEST_VERSION}" >> "$GITHUB_ENV"
+          echo "::notice title=Rehearsal build::Building ${TEST_VERSION} instead of the git-derived version. This is a dry run of the upload path, not a release."
 
       - name: Build sdist and wheel
         run: |
@@ -92,39 +119,64 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "is_release=true" >> "$GITHUB_OUTPUT"
-            echo "Built ${version}; publishing enabled."
+            echo "Built ${version}, a plain x.y.z release."
           else
             echo "is_release=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Nothing to publish::Built ${version}, which is not a plain x.y.z release. Artifacts are still verified and uploaded to the run. Tag a commit to publish."
+            echo "Built ${version}, which is not a plain x.y.z release."
           fi
 
-      - name: Check whether the target index already has this version
+      - name: Check the target index
         id: published
-        if: steps.version.outputs.is_release == 'true'
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          IS_RELEASE: ${{ steps.version.outputs.is_release }}
           TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'testpypi' }}
         run: |
           set -euo pipefail
           if [ "${TARGET}" = "pypi" ]; then host="pypi.org"; else host="test.pypi.org"; fi
+
           # 404 covers both "project does not exist yet" and "version not
-          # uploaded", which are the same answer for our purposes.
-          code="$(curl -sS --retry 3 --max-time 30 -o /dev/null -w '%{http_code}' \
-            "https://${host}/pypi/noodle-bucket/${VERSION}/json")"
-          case "${code}" in
-            404)
-              echo "already_published=false" >> "$GITHUB_OUTPUT"
-              echo "${host} does not have ${VERSION}; publishing."
-              ;;
-            200)
+          # uploaded", which are the same answer for our purposes. Anything
+          # else is a broken check rather than a licence to guess.
+          index_has() {
+            local code
+            code="$(curl -sS --retry 3 --max-time 30 -o /dev/null -w '%{http_code}' \
+              "https://${host}/pypi/noodle-bucket/$1/json")"
+            case "${code}" in
+              200) return 0 ;;
+              404) return 1 ;;
+              *)
+                echo "::error title=Index check failed::Unexpected HTTP ${code} from ${host} while checking $1."
+                exit 1
+                ;;
+            esac
+          }
+
+          if [ "${IS_RELEASE}" = "true" ]; then
+            if index_has "${VERSION}"; then
               echo "already_published=true" >> "$GITHUB_OUTPUT"
               echo "::notice title=Already published::${host} already has noodle-bucket ${VERSION}; skipping the upload."
-              ;;
-            *)
-              echo "::error title=Index check failed::Unexpected HTTP ${code} from ${host} while checking ${VERSION}."
-              exit 1
-              ;;
-          esac
+            else
+              echo "already_published=false" >> "$GITHUB_OUTPUT"
+              echo "${host} does not have ${VERSION}; publishing."
+            fi
+            exit 0
+          fi
+
+          # Not publishable from this ref. Name the tag that could be published
+          # instead, and whether it is already there, so the operator does not
+          # have to go and look it up.
+          tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ -z "${tag}" ]; then
+            echo "::notice title=Nothing to publish::Built ${VERSION} from ${GITHUB_REF}, which is not a plain x.y.z release, and the repository has no tags to fall back on."
+            exit 0
+          fi
+          if index_has "${tag#v}"; then
+            state="already on ${host}"
+          else
+            state="not yet on ${host}"
+          fi
+          echo "::notice title=Nothing to publish::Built ${VERSION} from ${GITHUB_REF}, which is not a plain x.y.z release. The most recent tag is ${tag} (${state}). To publish it, re-run with 'Use workflow from: ${tag}'."
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,7 +3,11 @@
 #
 # Publish the Python package. Tag pushes upload to TestPyPI only; production
 # PyPI is an explicit promote via workflow_dispatch (target=pypi) on that
-# same tag. Operator setup: .github/RELEASE_AUTOMATION.md.
+# same tag. Only plain x.y.z versions are uploaded: an untagged commit builds
+# as x.y.z.devN+gSHA, and the indexes reject local version segments, so those
+# runs build and verify but skip publishing. Re-running a tag is a no-op: the
+# target index is queried first and the upload is skipped if it already has
+# that version. Operator setup: .github/RELEASE_AUTOMATION.md.
 
 name: Publish to PyPI
 
@@ -31,7 +35,17 @@ jobs:
   build:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is_release: ${{ steps.version.outputs.is_release }}
+      already_published: ${{ steps.published.outputs.already_published }}
     steps:
+      - name: Reject production runs that are not on a tag
+        if: github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && !startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo "::error title=Production requires a tag::Run this workflow against a v* tag (Use workflow from <tag>)."
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@v7
         with:
@@ -42,18 +56,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-
-      - name: Use a throwaway version on untagged TestPyPI runs
-        if: github.event_name == 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/v')
-        run: |
-          set -euo pipefail
-          if [ "${{ inputs.target }}" = "pypi" ]; then
-            echo "::error title=Production requires a tag::Run this workflow against a v* tag to publish to PyPI."
-            exit 1
-          fi
-          # Local versions (+gSHA) are rejected by (Test)PyPI. A unique
-          # 0.0.<run>.dev0 is enough to prove the upload path from main.
-          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NOODLE_BUCKET=0.0.${GITHUB_RUN_NUMBER}.dev0" >> "$GITHUB_ENV"
 
       - name: Build sdist and wheel
         run: |
@@ -82,6 +84,48 @@ jobs:
           assert not any("/electron/" in n or n.endswith("/electron") for n in sdist_names), sdist_names
           PY
 
+      - name: Decide whether this version is publishable
+        id: version
+        run: |
+          set -euo pipefail
+          version="$(python -c 'import pathlib; print(next(pathlib.Path("dist").glob("*.whl")).name.split("-")[1])')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "Built ${version}; publishing enabled."
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Nothing to publish::Built ${version}, which is not a plain x.y.z release. Artifacts are still verified and uploaded to the run. Tag a commit to publish."
+          fi
+
+      - name: Check whether the target index already has this version
+        id: published
+        if: steps.version.outputs.is_release == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'testpypi' }}
+        run: |
+          set -euo pipefail
+          if [ "${TARGET}" = "pypi" ]; then host="pypi.org"; else host="test.pypi.org"; fi
+          # 404 covers both "project does not exist yet" and "version not
+          # uploaded", which are the same answer for our purposes.
+          code="$(curl -sS --retry 3 --max-time 30 -o /dev/null -w '%{http_code}' \
+            "https://${host}/pypi/noodle-bucket/${VERSION}/json")"
+          case "${code}" in
+            404)
+              echo "already_published=false" >> "$GITHUB_OUTPUT"
+              echo "${host} does not have ${VERSION}; publishing."
+              ;;
+            200)
+              echo "already_published=true" >> "$GITHUB_OUTPUT"
+              echo "::notice title=Already published::${host} already has noodle-bucket ${VERSION}; skipping the upload."
+              ;;
+            *)
+              echo "::error title=Index check failed::Unexpected HTTP ${code} from ${host} while checking ${VERSION}."
+              exit 1
+              ;;
+          esac
+
       - name: Upload distributions
         uses: actions/upload-artifact@v4
         with:
@@ -89,8 +133,12 @@ jobs:
           path: dist/
 
   publish-testpypi:
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
     needs: build
+    if: >-
+      needs.build.outputs.is_release == 'true' &&
+      needs.build.outputs.already_published == 'false' &&
+      (github.event_name == 'push' ||
+       (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'))
     runs-on: ubuntu-latest
     environment:
       name: testpypi
@@ -113,8 +161,13 @@ jobs:
           skip-existing: true
 
   publish-pypi:
-    if: github.event_name == 'workflow_dispatch' && inputs.target == 'pypi'
     needs: build
+    # The build job already fails a non-tag run targeting pypi, and only a tag
+    # can produce a plain x.y.z, so reaching here means both hold.
+    if: >-
+      needs.build.outputs.is_release == 'true' &&
+      needs.build.outputs.already_published == 'false' &&
+      github.event_name == 'workflow_dispatch' && inputs.target == 'pypi'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -122,14 +175,6 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Require a release tag
-        run: |
-          set -euo pipefail
-          if [[ "${GITHUB_REF}" != refs/tags/v* ]]; then
-            echo "::error title=Production requires a tag::Run this workflow against a v* tag (Use workflow from <tag>)."
-            exit 1
-          fi
-
       - name: Download distributions
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

The TestPyPI dry run from `main` failed with a 400: `The use of local versions in '2.7.3.dev2+g732f4c730' is not allowed`. The guard meant to prevent that set `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NOODLE_BUCKET`, which **hatch-vcs ignores entirely** — it doesn't pass the distribution name to setuptools-scm, so only the bare `SETUPTOOLS_SCM_PRETEND_VERSION` has any effect. The step ran and did nothing.

- **Only plain `x.y.z` publishes.** The build job reads the version off the wheel and gates both publish jobs on it. Untagged runs still build and run the Python-only assertions, but upload nothing.
- **Uploads are idempotent.** The target index is queried for that exact version first and the publish job is skipped if it's already there, so re-running a tag is a no-op rather than a duplicate-upload error. Anything other than `200`/`404` fails the run rather than guessing.
- **A rehearsal path.** Dispatching with target `testpypi` and `test_version=0.0.1` builds and uploads that exact version, proving OIDC, the environment, the pending publisher and the upload without cutting a tag. Rejected outright with `target=pypi`.
- **The no-op run is informative.** Rather than a generic notice, it names the most recent tag and whether the index already has it, so you know which ref to re-run from.

A throwaway `v*` tag would have been the obvious way to rehearse, but tag pushes also trigger `deploy-viewer.yml`, so it would publish the viewer site as a side effect.

The index check lives in `build` so the whole publish job is skipped — no deployment record, and no required reviewer prompted on `pypi` for a no-op.

## Test plan

- [x] Confirmed the root cause: `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NOODLE_BUCKET` and `HATCH_VCS_PRETEND_VERSION` are both ignored; only the bare variable changes the built version.
- [x] Gate logic over `2.7.3` (publish) and `2.7.3.dev5+gSHA`, `0.0.99.dev0`, `2.7.3rc1` (all skip), plus real tagged and untagged builds.
- [x] Probed the index endpoints: absent project, absent version and present version return the expected `404`/`200`.
- [x] Simulated the rehearsal build locally — `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.1` produces `noodle_bucket-0.0.1`, which passes the gate, and `0.0.1` is currently free on TestPyPI.
- [ ] Run the rehearsal for real and smoke-test the install.
- [ ] Then cut a tag and confirm the automatic upload, and that re-running it skips.

> [!NOTE]
> Only strict `x.y.z` is publishable, so a pre-release tag such as `v2.8.0rc1` would build but not upload. `tag-release-on-merge.yml` only ever cuts plain versions, so nothing hits that today.
