### PR TITLE
[Patch] Stop advertising a --web-path default that cannot exist

### DIFF
--- a/bucket/__main__.py
+++ b/bucket/__main__.py
@@ -26,7 +26,10 @@ from .rw.html import DEFAULT_WEB_PATH
     "--web-path",
     help="Path to the web viewer (only used by html/report)",
     default=DEFAULT_WEB_PATH,
-    show_default=True,
+    # On a pip install the default resolves inside site-packages, where the
+    # viewer is never shipped. Printing that path in --help reads like a
+    # broken install, so only advertise it when it is really there.
+    show_default=DEFAULT_WEB_PATH.is_dir(),
     type=click.Path(path_type=Path),
 )
 def cli(ctx, web_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,6 +79,19 @@ class TestCli:
         assert result.exit_code == 0
         assert "version" in result.output
 
+    def test_web_path_default_only_advertised_when_it_exists(self):
+        """
+        The wheel ships no viewer, so on a pip install the --web-path default
+        resolves to a site-packages path that cannot exist. Printing it in
+        --help reads like a broken install. --web-path is the only option here
+        with a default, so `[default:` tracks whether it is advertised.
+        """
+        from bucket.rw.html import DEFAULT_WEB_PATH
+
+        result = self.run("--help")
+        assert result.exit_code == 0
+        assert ("[default:" in result.output) == DEFAULT_WEB_PATH.is_dir()
+
     def test_write_console(self, archives):
         path_1, *_ = archives
         result = self.run("write", "-r", path_1, "console")


### PR DESCRIPTION
## Summary

Found by installing the published `noodle-bucket` 2.7.3 from PyPI and running `bucket --help`:

```
--web-path PATH  Path to the web viewer (only used by html/report)
                 [default: /.../site-packages/viewer]
```

The wheel deliberately ships no viewer, so that path can never exist on a pip install. Advertising it reads like something failed to install, and it's the first thing a new user sees.

Only advertise the default when the directory is really there. A source checkout still gets the useful path; a pip user gets nothing misleading.

```python
default=DEFAULT_WEB_PATH,
show_default=DEFAULT_WEB_PATH.is_dir(),
```

The test asserts the invariant — shown if and only if it exists — rather than either outcome, so it holds both in a checkout and in an installed environment.

## Test plan

- [x] Full suite passes (`194 passed`).
- [x] Source checkout still prints `[default: /.../bucket/viewer]`.
- [x] Built the wheel, installed into a clean venv, and confirmed the default line is gone and the invariant holds there.