### PR TITLE
[None] Comment the PyPI link on the source PR after publishing

### DIFF
--- a/.github/RELEASE_AUTOMATION.md
+++ b/.github/RELEASE_AUTOMATION.md
@@ -119,6 +119,11 @@ number reused, even after deleting it. Fix forward with the next tag.
 Merge a PR titled `[Patch]`, `[Minor]` or `[Major]`. That cuts the tag,
 which uploads to PyPI and deploys the viewer. Nothing else is needed.
 
+The source PR gets two comments from **noodle-bucket-releases**: "Shipped
+in vX.Y.Z" when the tag is cut, and a second linking the PyPI release once
+the upload has actually succeeded. The absence of the second one means the
+publish failed or was skipped.
+
 To retry a release that failed partway, run *Actions → Publish to PyPI →
 Run workflow* with **Use workflow from** set to the tag. Dispatching from a
 branch with the default `pypi` target fails deliberately, naming the most

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -242,6 +242,56 @@ jobs:
         # refs/tags/v1.14.2 -> dc37677b2e1c63e2034f94d8a5b11f265b73ba33
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
 
+  # tag-release-on-merge.yml comments "Shipped in vX.Y.Z" when the tag is cut,
+  # which is before this workflow has uploaded anything. This is a second,
+  # separate comment posted only once the upload actually succeeded, so the
+  # link is never dead. Skipped automatically when publish-pypi is skipped.
+  comment-on-pr:
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Same App as the "Shipped in" comment, so both come from the same bot.
+      - name: Mint noodle-bucket-releases app token
+        id: app_token
+        continue-on-error: true
+        # actions/create-github-app-token v3.1.1 (2026-04-11)
+        # refs/tags/v3.1.1 -> 1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+        with:
+          app-id: ${{ secrets.NOODLE_APP_ID }}
+          private-key: ${{ secrets.NOODLE_APP_PRIVATE_KEY }}
+
+      # Never fail a successful release over a comment.
+      - name: Link the PyPI release on the source PR
+        if: steps.app_token.outputs.token != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ needs.build.outputs.version }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          url="https://pypi.org/project/noodle-bucket/${VERSION}/"
+
+          # The tag points at the squash-merge commit, so this resolves back to
+          # the PR that caused the release. A manual release has no PR.
+          pr="$(gh api "repos/${GH_REPO}/commits/${SHA}/pulls" --jq '.[0].number // empty')"
+          if [ -z "${pr}" ]; then
+            echo "No PR associated with ${SHA}; nothing to comment on."
+            exit 0
+          fi
+
+          # Re-running a dispatch against the same tag must not double-post.
+          if gh pr view "${pr}" --json comments --jq '.comments[].body' | grep -qF "${url}"; then
+            echo "PR #${pr} already links ${url}."
+            exit 0
+          fi
+
+          gh pr comment "${pr}" --body "📦 Published to PyPI: [\`noodle-bucket ${VERSION}\`](${url})"
+
   attach-release:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build


### PR DESCRIPTION
## Summary

`tag-release-on-merge.yml` already comments "🪣 Shipped in vX.Y.Z" when the tag is cut — but that happens *before* this workflow has uploaded anything. Putting the PyPI URL in that comment would link a page that doesn't exist yet, and would stay dead if the publish then failed.

So this is a second, separate comment, posted from `publish-pypi.yml` only once the upload has actually succeeded:

> 📦 Published to PyPI: [`noodle-bucket 2.7.5`](https://pypi.org/project/noodle-bucket/2.7.5/)

Absence of it becomes a signal in itself — the tag was cut but the package didn't ship.

- Resolves the PR from the tagged commit via the commit→PRs API, so it finds the squash-merge's source PR. A manual release has no PR and is skipped quietly.
- Uses the same **noodle-bucket-releases** App as the first comment, so both come from the same bot rather than one appearing as `github-actions[bot]`.
- Skips if the link is already present, so re-running a dispatch against the same tag can't double-post.
- `continue-on-error` throughout — a comment must never fail a successful release. The job also skips automatically whenever `publish-pypi` skips.

## Test plan

- [x] Verified the commit→PR lookup against the last three real squash merges: resolves #192, #191 and #190 correctly.
- [x] Verified the duplicate check against a real PR's comment bodies.
- [x] `check yaml` passes; the job graph has `comment-on-pr` depending on `build` and `publish-pypi`.
- [ ] Confirm on the next release that the comment appears with a working link.