### PR TITLE
[Patch] Fix empty pivot table when an axis is named target

### DIFF
--- a/viewer/src/features/Dashboard/lib/pivottable.test.ts
+++ b/viewer/src/features/Dashboard/lib/pivottable.test.ts
@@ -5,93 +5,144 @@
 
 import { describe, expect, test } from "vitest";
 import CoverageTree from "./coveragetree";
-import { buildBucketRecords } from "./pivottable";
+import { aggregatePivotCells, buildBucketRecords } from "./pivottable";
 import { InMemoryReadout } from "@/services/readoutUtils";
 
-describe("buildBucketRecords", () => {
-    test("keeps goal targets when an axis is named target", () => {
-        const readout = new InMemoryReadout({
-            defSha: "def",
-            recSha: "rec",
-            source: "test",
-            sourceKey: "1",
-            bucketVersion: "",
-            points: [
-                {
-                    start: 0,
-                    depth: 0,
-                    end: 1,
-                    axis_start: 0,
-                    axis_end: 2,
-                    axis_value_start: 0,
-                    axis_value_end: 4,
-                    goal_start: 0,
-                    goal_end: 1,
-                    bucket_start: 0,
-                    bucket_end: 4,
-                    target: 4,
-                    name: "jump_operations",
-                    description: "",
-                },
-            ],
-            axes: [
-                {
-                    start: 0,
-                    value_start: 0,
-                    value_end: 2,
-                    name: "jump_type",
-                    description: "",
-                },
-                {
-                    start: 1,
-                    value_start: 2,
-                    value_end: 4,
-                    name: "target",
-                    description: "",
-                },
-            ],
-            axisValues: [
-                { start: 0, value: "JAL" },
-                { start: 1, value: "JALR" },
-                { start: 2, value: "lo" },
-                { start: 3, value: "hi" },
-            ],
-            goals: [{ start: 0, name: "DEFAULT", description: "", target: 10 }],
-            bucketGoals: [
-                { start: 0, goal: 0 },
-                { start: 1, goal: 0 },
-                { start: 2, goal: 0 },
-                { start: 3, goal: 0 },
-            ],
-            pointHits: [{ start: 0, hits: 20, hit_buckets: 2, full_buckets: 2 }],
-            bucketHits: [
-                { start: 0, hits: 10 },
-                { start: 1, hits: 0 },
-                { start: 2, hits: 10 },
-                { start: 3, hits: 0 },
-            ],
-        });
+/** Former flat-record keys plus current BucketRecord fields that must not clash with axes. */
+const RESERVED_AXIS_NAMES = [
+    "target",
+    "hits",
+    "axes",
+    "hitCount",
+    "goalTarget",
+    "rowKey",
+    "rowLabel",
+    "sumHits",
+    "sumTargets",
+    "bucketCount",
+] as const;
 
-        const tree = CoverageTree.fromReadouts([readout]);
-        const node = tree.getRoots()[0];
-        expect(node).toBeTruthy();
-
-        const { buckets, axisNames } = buildBucketRecords(node as never);
-        expect(axisNames).toEqual(["jump_type", "target"]);
-        expect(buckets).toHaveLength(4);
-        for (const bucket of buckets) {
-            expect(bucket.goalTarget).toBe(10);
-            expect(typeof bucket.axes.target).toBe("string");
-            expect(bucket.axes.target === "lo" || bucket.axes.target === "hi").toBe(true);
-        }
-        expect(buckets.map((b) => b.hitCount)).toEqual([10, 0, 10, 0]);
-
-        // Pivot aggregation must stay numeric even with a "target" axis.
-        let sumTargets = 0;
-        for (const bucket of buckets) {
-            sumTargets += bucket.goalTarget;
-        }
-        expect(sumTargets).toBe(40);
-        expect(typeof sumTargets).toBe("number");
+function readoutWithClashAxis(clashAxisName: string): InMemoryReadout {
+    return new InMemoryReadout({
+        defSha: "def",
+        recSha: "rec",
+        source: "test",
+        sourceKey: "1",
+        bucketVersion: "",
+        points: [
+            {
+                start: 0,
+                depth: 0,
+                end: 1,
+                axis_start: 0,
+                axis_end: 2,
+                axis_value_start: 0,
+                axis_value_end: 4,
+                goal_start: 0,
+                goal_end: 1,
+                bucket_start: 0,
+                bucket_end: 4,
+                target: 4,
+                name: "clash_coverpoint",
+                description: "",
+            },
+        ],
+        axes: [
+            {
+                start: 0,
+                value_start: 0,
+                value_end: 2,
+                name: "kind",
+                description: "",
+            },
+            {
+                start: 1,
+                value_start: 2,
+                value_end: 4,
+                name: clashAxisName,
+                description: "",
+            },
+        ],
+        axisValues: [
+            { start: 0, value: "A" },
+            { start: 1, value: "B" },
+            { start: 2, value: "lo" },
+            { start: 3, value: "hi" },
+        ],
+        goals: [{ start: 0, name: "DEFAULT", description: "", target: 10 }],
+        bucketGoals: [
+            { start: 0, goal: 0 },
+            { start: 1, goal: 0 },
+            { start: 2, goal: 0 },
+            { start: 3, goal: 0 },
+        ],
+        pointHits: [{ start: 0, hits: 20, hit_buckets: 2, full_buckets: 2 }],
+        bucketHits: [
+            { start: 0, hits: 10 },
+            { start: 1, hits: 0 },
+            { start: 2, hits: 10 },
+            { start: 3, hits: 0 },
+        ],
     });
+}
+
+describe("buildBucketRecords", () => {
+    test.each(RESERVED_AXIS_NAMES)(
+        "keeps numeric metrics when an axis is named %s",
+        (clashAxisName) => {
+            const tree = CoverageTree.fromReadouts([readoutWithClashAxis(clashAxisName)]);
+            const node = tree.getRoots()[0];
+            const { buckets, axisNames } = buildBucketRecords(node as never);
+
+            expect(axisNames).toEqual(["kind", clashAxisName]);
+            expect(buckets).toHaveLength(4);
+            for (const bucket of buckets) {
+                expect(bucket.goalTarget).toBe(10);
+                expect(typeof bucket.hitCount).toBe("number");
+                expect(bucket.axes[clashAxisName] === "lo" || bucket.axes[clashAxisName] === "hi").toBe(
+                    true,
+                );
+            }
+            expect(buckets.map((b) => b.hitCount)).toEqual([10, 0, 10, 0]);
+        },
+    );
+});
+
+describe("aggregatePivotCells", () => {
+    test.each(RESERVED_AXIS_NAMES)(
+        "aggregates numeric cells when an axis is named %s",
+        (clashAxisName) => {
+            const tree = CoverageTree.fromReadouts([readoutWithClashAxis(clashAxisName)]);
+            const { buckets } = buildBucketRecords(tree.getRoots()[0] as never);
+            const { cellMap, rowKeys, colKeys } = aggregatePivotCells(
+                buckets,
+                ["kind"],
+                [clashAxisName],
+            );
+
+            expect(rowKeys).toEqual(["A", "B"]);
+            expect(colKeys).toEqual(["hi", "lo"]);
+
+            const cellALo = cellMap.get("A\tlo");
+            expect(cellALo).toEqual({
+                sumHits: 10,
+                sumTargets: 10,
+                bucketCount: 1,
+            });
+            expect(typeof cellALo!.sumTargets).toBe("number");
+
+            const cellAHi = cellMap.get("A\thi");
+            expect(cellAHi).toEqual({
+                sumHits: 0,
+                sumTargets: 10,
+                bucketCount: 1,
+            });
+
+            // Ratio used by the table renderer must be finite (not NaN from string concat).
+            for (const cell of cellMap.values()) {
+                const ratio = cell.sumTargets !== 0 ? cell.sumHits / cell.sumTargets : Number.NaN;
+                expect(Number.isFinite(ratio)).toBe(true);
+            }
+        },
+    );
 });

--- a/viewer/src/features/Dashboard/lib/pivottable.test.ts
+++ b/viewer/src/features/Dashboard/lib/pivottable.test.ts
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+ */
+
+import { describe, expect, test } from "vitest";
+import CoverageTree from "./coveragetree";
+import { buildBucketRecords } from "./pivottable";
+import { InMemoryReadout } from "@/services/readoutUtils";
+
+describe("buildBucketRecords", () => {
+    test("keeps goal targets when an axis is named target", () => {
+        const readout = new InMemoryReadout({
+            defSha: "def",
+            recSha: "rec",
+            source: "test",
+            sourceKey: "1",
+            bucketVersion: "",
+            points: [
+                {
+                    start: 0,
+                    depth: 0,
+                    end: 1,
+                    axis_start: 0,
+                    axis_end: 2,
+                    axis_value_start: 0,
+                    axis_value_end: 4,
+                    goal_start: 0,
+                    goal_end: 1,
+                    bucket_start: 0,
+                    bucket_end: 4,
+                    target: 4,
+                    name: "jump_operations",
+                    description: "",
+                },
+            ],
+            axes: [
+                {
+                    start: 0,
+                    value_start: 0,
+                    value_end: 2,
+                    name: "jump_type",
+                    description: "",
+                },
+                {
+                    start: 1,
+                    value_start: 2,
+                    value_end: 4,
+                    name: "target",
+                    description: "",
+                },
+            ],
+            axisValues: [
+                { start: 0, value: "JAL" },
+                { start: 1, value: "JALR" },
+                { start: 2, value: "lo" },
+                { start: 3, value: "hi" },
+            ],
+            goals: [{ start: 0, name: "DEFAULT", description: "", target: 10 }],
+            bucketGoals: [
+                { start: 0, goal: 0 },
+                { start: 1, goal: 0 },
+                { start: 2, goal: 0 },
+                { start: 3, goal: 0 },
+            ],
+            pointHits: [{ start: 0, hits: 20, hit_buckets: 2, full_buckets: 2 }],
+            bucketHits: [
+                { start: 0, hits: 10 },
+                { start: 1, hits: 0 },
+                { start: 2, hits: 10 },
+                { start: 3, hits: 0 },
+            ],
+        });
+
+        const tree = CoverageTree.fromReadouts([readout]);
+        const node = tree.getRoots()[0];
+        expect(node).toBeTruthy();
+
+        const { buckets, axisNames } = buildBucketRecords(node as never);
+        expect(axisNames).toEqual(["jump_type", "target"]);
+        expect(buckets).toHaveLength(4);
+        for (const bucket of buckets) {
+            expect(bucket.goalTarget).toBe(10);
+            expect(typeof bucket.axes.target).toBe("string");
+            expect(bucket.axes.target === "lo" || bucket.axes.target === "hi").toBe(true);
+        }
+        expect(buckets.map((b) => b.hitCount)).toEqual([10, 0, 10, 0]);
+
+        // Pivot aggregation must stay numeric even with a "target" axis.
+        let sumTargets = 0;
+        for (const bucket of buckets) {
+            sumTargets += bucket.goalTarget;
+        }
+        expect(sumTargets).toBe(40);
+        expect(typeof sumTargets).toBe("number");
+    });
+});

--- a/viewer/src/features/Dashboard/lib/pivottable.tsx
+++ b/viewer/src/features/Dashboard/lib/pivottable.tsx
@@ -58,12 +58,16 @@ function setDragData(e: React.DragEvent, data: AxisDragData) {
 const KEY_SEP = "\u001f";
 
 type BucketRecord = {
-    [axisName: string]: string | number;
-    hits: number;
-    target: number;
+    /** Axis name → value. Kept separate so names like "target" cannot clobber metrics. */
+    axes: Record<string, string>;
+    hitCount: number;
+    goalTarget: number;
 };
 
-function buildBucketRecords(node: PointNode): { buckets: BucketRecord[]; axisNames: string[] } {
+export function buildBucketRecords(node: PointNode): {
+    buckets: BucketRecord[];
+    axisNames: string[];
+} {
     const pointData = node.data;
     const readout = pointData.readout;
     const {
@@ -87,20 +91,21 @@ function buildBucketRecords(node: PointNode): { buckets: BucketRecord[]; axisNam
     for (const bucketGoal of readout.iter_bucket_goals(bucket_start, bucket_end)) {
         const bucketHit = bucketHits.next().value;
         const goal = goals[bucketGoal.goal - goal_start];
-        const datum: BucketRecord = {
-            hits: bucketHit.hits,
-            target: goal.target,
-        };
+        const axisMap: Record<string, string> = {};
         let offset = bucketGoal.start - bucket_start;
         for (let axisIdx = axes.length - 1; axisIdx >= 0; axisIdx--) {
             const axis = axes[axisIdx];
             const axisOffset = axis.value_start - axis_value_start;
             const axisSize = axis.value_end - axis.value_start;
             const axisValueIdx = offset % axisSize;
-            datum[axis.name] = axisValues[axisOffset + axisValueIdx].value;
+            axisMap[axis.name] = String(axisValues[axisOffset + axisValueIdx].value);
             offset = Math.floor(offset / axisSize);
         }
-        buckets.push(datum);
+        buckets.push({
+            axes: axisMap,
+            hitCount: bucketHit.hits,
+            goalTarget: goal.target,
+        });
     }
 
     return { buckets, axisNames: axes.map((a) => a.name) };
@@ -108,9 +113,7 @@ function buildBucketRecords(node: PointNode): { buckets: BucketRecord[]; axisNam
 
 function keyFor(record: BucketRecord, axisNames: string[]): string {
     if (axisNames.length === 0) return "";
-    return axisNames
-        .map((name) => String(record[name] ?? ""))
-        .join(KEY_SEP);
+    return axisNames.map((name) => record.axes[name] ?? "").join(KEY_SEP);
 }
 
 function labelForKey(key: string): string {
@@ -137,10 +140,10 @@ function suggestAxesAll(
     for (const axisName of axisNames) {
         const byValue = new Map<string, { hits: number; target: number }>();
         for (const b of buckets) {
-            const v = String(b[axisName] ?? "");
+            const v = b.axes[axisName] ?? "";
             const cur = byValue.get(v) ?? { hits: 0, target: 0 };
-            cur.hits += b.hits;
-            cur.target += b.target;
+            cur.hits += b.hitCount;
+            cur.target += b.goalTarget;
             byValue.set(v, cur);
         }
 
@@ -416,8 +419,8 @@ export function PointPivotView({ node }: PointPivotViewProps) {
                 sumTargets: 0,
                 bucketCount: 0,
             };
-            cur.sumHits += b.hits;
-            cur.sumTargets += b.target;
+            cur.sumHits += b.hitCount;
+            cur.sumTargets += b.goalTarget;
             cur.bucketCount += 1;
             cellMap.set(key, cur);
         }

--- a/viewer/src/features/Dashboard/lib/pivottable.tsx
+++ b/viewer/src/features/Dashboard/lib/pivottable.tsx
@@ -116,6 +116,52 @@ function keyFor(record: BucketRecord, axisNames: string[]): string {
     return axisNames.map((name) => record.axes[name] ?? "").join(KEY_SEP);
 }
 
+export type PivotCellInfo = {
+    sumHits: number;
+    sumTargets: number;
+    bucketCount: number;
+};
+
+/** Aggregate bucket metrics into pivot cells keyed by ``row\\tcol``. */
+export function aggregatePivotCells(
+    buckets: BucketRecord[],
+    rowAxes: string[],
+    colAxes: string[],
+): {
+    rowKeys: string[];
+    colKeys: string[];
+    cellMap: Map<string, PivotCellInfo>;
+} {
+    const rowKeySet = new Set<string>();
+    const colKeySet = new Set<string>();
+    for (const b of buckets) {
+        rowKeySet.add(keyFor(b, rowAxes));
+        colKeySet.add(keyFor(b, colAxes));
+    }
+    if (rowAxes.length === 0) rowKeySet.add("");
+    if (colAxes.length === 0) colKeySet.add("");
+    const rowKeys = Array.from(rowKeySet).sort();
+    const colKeys = Array.from(colKeySet).sort();
+
+    const cellMap = new Map<string, PivotCellInfo>();
+    for (const b of buckets) {
+        const rk = rowAxes.length ? keyFor(b, rowAxes) : "";
+        const ck = colAxes.length ? keyFor(b, colAxes) : "";
+        const key = `${rk}\t${ck}`;
+        const cur = cellMap.get(key) ?? {
+            sumHits: 0,
+            sumTargets: 0,
+            bucketCount: 0,
+        };
+        cur.sumHits += b.hitCount;
+        cur.sumTargets += b.goalTarget;
+        cur.bucketCount += 1;
+        cellMap.set(key, cur);
+    }
+
+    return { rowKeys, colKeys, cellMap };
+}
+
 function labelForKey(key: string): string {
     if (!key) return "—";
     return key.split(KEY_SEP).join(" | ");
@@ -395,35 +441,7 @@ export function PointPivotView({ node }: PointPivotViewProps) {
     );
 
     const { rowKeys, colKeys, cellMap, rowKeyToLabel, rowSpans } = useMemo(() => {
-        const rowKeySet = new Set<string>();
-        const colKeySet = new Set<string>();
-        for (const b of buckets) {
-            rowKeySet.add(keyFor(b, rowAxes));
-            colKeySet.add(keyFor(b, colAxes));
-        }
-        if (rowAxes.length === 0) rowKeySet.add("");
-        if (colAxes.length === 0) colKeySet.add("");
-        const rowKeys = Array.from(rowKeySet).sort();
-        const colKeys = Array.from(colKeySet).sort();
-
-        const cellMap = new Map<
-            string,
-            { sumHits: number; sumTargets: number; bucketCount: number }
-        >();
-        for (const b of buckets) {
-            const rk = rowAxes.length ? keyFor(b, rowAxes) : "";
-            const ck = colAxes.length ? keyFor(b, colAxes) : "";
-            const key = `${rk}\t${ck}`;
-            const cur = cellMap.get(key) ?? {
-                sumHits: 0,
-                sumTargets: 0,
-                bucketCount: 0,
-            };
-            cur.sumHits += b.hitCount;
-            cur.sumTargets += b.goalTarget;
-            cur.bucketCount += 1;
-            cellMap.set(key, cur);
-        }
+        const { rowKeys, colKeys, cellMap } = aggregatePivotCells(buckets, rowAxes, colAxes);
 
         const rowKeyToLabel = new Map<string, string>();
         for (const rk of rowKeys) rowKeyToLabel.set(rk, labelForKey(rk));


### PR DESCRIPTION
## Summary
- Pivot cells showed `-` for coverpoints with an axis named `target` (notably RISC-V `jump_operations`), because goal targets were stored on the same object as axis values and got overwritten.
- Keep axis values and hit/target metrics separate; add a regression test.

## Test plan
- [ ] Open `jump_operations`, switch to Pivot, put `jump_type` on rows and `rd` on columns — cells show percentages, not `-`
- [ ] Confirm tooltips still show bucket counts / hits
- [ ] `cd viewer && npx vitest run src/features/Dashboard/lib/pivottable.test.ts`