### PR TITLE
[None] Load bundled example coverage in the Electron app

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -820,6 +820,30 @@ ipcMain.handle('read-file', async (event, filePath) => {
   }
 });
 
+// Bundled empty-state example (viewer/public → dist/examples via Vite).
+ipcMain.handle('read-bundled-example-coverage', async () => {
+  const relativeExample = path.join('examples', 'riscv_stress_viewer_demo.bktgz');
+  const candidates = [
+    path.join(distPath, relativeExample),
+    // Dev / incomplete builds: fall back to the source public asset.
+    path.join(__dirname, '..', 'viewer', 'public', relativeExample),
+  ];
+  for (const candidate of candidates) {
+    try {
+      return await fsp.readFile(candidate);
+    } catch (error) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        continue;
+      }
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to read bundled example coverage: ${detail}`);
+    }
+  }
+  throw new Error(
+    `Bundled example coverage not found. Looked in:\n${candidates.join('\n')}`,
+  );
+});
+
 // Handle exporting files
 ipcMain.handle('save-export-file', async (event, payload) => {
   try {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -21,6 +21,7 @@ ipcRenderer.on('files-opened', (_event, filePaths) => {
 contextBridge.exposeInMainWorld('electronAPI', {
   openFileDialog: () => ipcRenderer.invoke('open-file-dialog'),
   readFile: (filePath) => ipcRenderer.invoke('read-file', filePath),
+  readBundledExampleCoverage: () => ipcRenderer.invoke('read-bundled-example-coverage'),
   saveExportFile: (payload) => ipcRenderer.invoke('save-export-file', payload),
   getDroppedFiles: (filePaths) => ipcRenderer.invoke('get-dropped-file', filePaths),
   onFilesOpened: (callback) => {

--- a/viewer/src/services/fileLoader.test.ts
+++ b/viewer/src/services/fileLoader.test.ts
@@ -7,7 +7,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 
-import { loadReadoutsFromBytes, EXAMPLE_COVERAGE_ARCHIVE } from "./fileLoader";
+import { loadReadoutsFromBytes, EXAMPLE_COVERAGE_ARCHIVE, resolveBundledAssetUrl } from "./fileLoader";
 import {
     BASE_POINT_COLUMNS,
     createBaseDefinition,
@@ -77,5 +77,14 @@ describe("bundled example coverage", () => {
         expect(readouts[1].get_source()).toBe("riscv_compare");
         expect(readouts[0].get_source_key()).toBe("baseline");
         expect(readouts[1].get_source_key()).toBe("improved");
+    });
+
+    test("resolveBundledAssetUrl uses app:// for the Electron protocol", () => {
+        expect(resolveBundledAssetUrl(EXAMPLE_COVERAGE_ARCHIVE, "app:")).toBe(
+            `app://${EXAMPLE_COVERAGE_ARCHIVE}`,
+        );
+        expect(resolveBundledAssetUrl(EXAMPLE_COVERAGE_ARCHIVE, "http:")).toBe(
+            `/${EXAMPLE_COVERAGE_ARCHIVE}`,
+        );
     });
 });

--- a/viewer/src/services/fileLoader.ts
+++ b/viewer/src/services/fileLoader.ts
@@ -54,11 +54,44 @@ export async function loadReadoutsFromBytes(bytes: Uint8Array): Promise<Readout[
 export const EXAMPLE_COVERAGE_ARCHIVE =
     "examples/riscv_stress_viewer_demo.bktgz";
 
+function exampleCoverageFileName(): string {
+    return EXAMPLE_COVERAGE_ARCHIVE.split("/").pop() ?? "example.bktgz";
+}
+
+/**
+ * Resolve a viewer public-asset path for fetch.
+ * Packaged Electron serves the viewer over `app://`, where absolute `/…`
+ * URLs do not follow `<base href="app://">` — same issue as the logo asset.
+ */
+export function resolveBundledAssetUrl(
+    relativePath: string,
+    locationProtocol: string = typeof window !== "undefined"
+        ? window.location.protocol
+        : "http:",
+): string {
+    const normalized = relativePath.replace(/^\//, "");
+    if (locationProtocol === "app:") {
+        return `app://${normalized}`;
+    }
+    const base = import.meta.env.BASE_URL || "/";
+    return `${base}${normalized}`;
+}
+
 /**
  * Fetch the bundled example coverage archive as a File for the normal load path.
+ *
+ * In Electron, read via IPC from the packaged viewer dist (or public/ in
+ * source checkouts) so we do not depend on custom-protocol fetch.
  */
 export async function fetchExampleCoverageFile(): Promise<File> {
-    const url = `${import.meta.env.BASE_URL}${EXAMPLE_COVERAGE_ARCHIVE}`;
+    const fileName = exampleCoverageFileName();
+
+    if (isElectron() && window.electronAPI?.readBundledExampleCoverage) {
+        const bytes = await window.electronAPI.readBundledExampleCoverage();
+        return new File([bytes], fileName, { type: "application/gzip" });
+    }
+
+    const url = resolveBundledAssetUrl(EXAMPLE_COVERAGE_ARCHIVE);
     const response = await fetch(url);
     if (!response.ok) {
         throw new Error(
@@ -66,7 +99,6 @@ export async function fetchExampleCoverageFile(): Promise<File> {
         );
     }
     const buffer = await response.arrayBuffer();
-    const fileName = EXAMPLE_COVERAGE_ARCHIVE.split("/").pop() ?? "example.bktgz";
     return new File([buffer], fileName, { type: "application/gzip" });
 }
 

--- a/viewer/src/vite-env.d.ts
+++ b/viewer/src/vite-env.d.ts
@@ -8,6 +8,7 @@
 interface ElectronAPI {
   openFileDialog: () => Promise<string[] | null>;
   readFile: (filePath: string) => Promise<Uint8Array>;
+  readBundledExampleCoverage: () => Promise<Uint8Array>;
   getDroppedFile: (filePath: string) => Promise<Uint8Array | null>;
   saveExportFile: (payload: {
     bytes: Uint8Array;


### PR DESCRIPTION
## Summary
- Example data was already copied into `viewer/dist` (and thus Electron `extraResources`), but **Try with example data** failed in the packaged app because fetch used `/examples/…`, which does not resolve under `app://`.
- Electron now reads the bundled archive via IPC from `viewer/dist/examples/` (falls back to `viewer/public/examples/` in source checkouts).
- Web/PWA still fetch the public asset; `app://` URLs are resolved correctly if needed.

## Test plan
- [ ] Packaged Mac app: empty state → **Try with example data** loads the RISC-V demo and opens Compare
- [ ] Electron dev (`npm run dev` against viewer on :4000): same button works
- [ ] Hosted viewer / local vite: example load still works
- [ ] `cd viewer && npx vitest run src/services/fileLoader.test.ts`