### PR TITLE
[Patch] Add tag: and tier: coverage tree search with autocomplete

### DIFF
--- a/docs/viewing_coverage.md
+++ b/docs/viewing_coverage.md
@@ -169,6 +169,12 @@ The navigation tree on the left can be expanded, collapsed, and searched.
   <img alt="Screenshot showing searching the covertree for the word 'chew'" src="https://raw.githubusercontent.com/Noodle-Bytes/bucket/main/.github/images/Search__dark.png">
 </picture>
 
+The coverage tree search box matches point names and also accepts keywords:
+`tag:name` and `tier:N`. While typing `tag:…` or `tier:…`, matching values appear
+as clickable suggestions. Plain typing also suggests matching tags (and tiers when
+the token is numeric); choosing a suggestion inserts the `tag:` / `tier:` filter.
+Active search prunes the tree to matching coverpoints and their ancestors.
+
 Selecting a coverpoint shows its buckets, goals, hit counts, and hit percentage.
 Axis columns and goal names can be filtered; columns can be sorted. Summary views
 also support tier and tag filters, and can be shown as a table or donut chart.

--- a/viewer/src/features/Dashboard/components/Sider/index.tsx
+++ b/viewer/src/features/Dashboard/components/Sider/index.tsx
@@ -8,11 +8,21 @@
  * Copyright (c) 2023-2024 Vypercore. All Rights Reserved
  */
 
-import { Layout, Tree as AntTree, Input } from "antd";
+import { AutoComplete, Layout, Tree as AntTree, Input } from "antd";
 import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 
 import { view } from "../../theme";
 import Tree, { TreeKey, TreeNode } from "../../lib/tree";
+import {
+    applyTreeSearchSuggestion,
+    buildTreeSearchSuggestions,
+    collectTreeTags,
+    collectTreeTiers,
+    filterTreeToMatches,
+    matchingTreeKeysWithAncestors,
+    parseTreeSearchQuery,
+    treeSearchIsActive,
+} from "../../lib/treeSearch";
 import Theme from "@/providers/Theme";
 import { hexToRgba } from "@/utils/colors";
 
@@ -27,7 +37,7 @@ export const MAX_SIDEBAR_WIDTH = 520;
  * @returns a formatted tree of nodes
  */
 function treeTitleFormatter(
-    tree: Tree,
+    nodes: TreeNode[],
     nodeTitleFormatter: (treeNode: TreeNode) => ReactNode,
     compareBadge?: (treeNode: TreeNode) => number | null,
     badgeColors?: { background: string; color: string },
@@ -61,7 +71,7 @@ function treeTitleFormatter(
             children: treeNode.children?.map(callback),
         };
     };
-    return tree.getRoots().map(callback);
+    return nodes.map(callback);
 }
 
 /**
@@ -71,17 +81,22 @@ function treeTitleFormatter(
  * @returns a formatted title with the search value highlighted
  */
 function searchNodeTitleFormatterFactory(searchValue: string) {
+    const nameTerms = parseTreeSearchQuery(searchValue).nameTerms;
+    const highlightTerm = nameTerms[0] ?? "";
     return (treeNode: TreeNode) => {
         const strTitle = treeNode.title as string;
-        const index = strTitle.indexOf(searchValue);
+        if (!highlightTerm) {
+            return <span>{strTitle}</span>;
+        }
+        const index = strTitle.indexOf(highlightTerm);
         const beforeStr = strTitle.substring(0, index);
-        const afterStr = strTitle.slice(index + searchValue.length);
+        const afterStr = strTitle.slice(index + highlightTerm.length);
         const title =
             index > -1 ? (
                 <span>
                     {beforeStr}
                     <span {...view.sider.tree.searchlight.props}>
-                        {searchValue}
+                        {highlightTerm}
                     </span>
                     {afterStr}
                 </span>
@@ -134,6 +149,33 @@ export default function Sider({
         [theme],
     );
 
+    const allTags = useMemo(() => collectTreeTags(tree.walk()), [tree]);
+    const allTiers = useMemo(() => collectTreeTiers(tree.walk()), [tree]);
+
+    const parsedQuery = useMemo(() => parseTreeSearchQuery(searchValue), [searchValue]);
+
+    const searchSuggestions = useMemo(
+        () => buildTreeSearchSuggestions(searchValue, parsedQuery, allTags, allTiers),
+        [searchValue, parsedQuery, allTags, allTiers],
+    );
+
+    const searchMatch = useMemo(() => {
+        if (!treeSearchIsActive(parsedQuery)) {
+            return null;
+        }
+        return matchingTreeKeysWithAncestors(tree.walk(), parsedQuery);
+    }, [tree, parsedQuery]);
+
+    const applySearchValue = (value: string) => {
+        const query = parseTreeSearchQuery(value);
+        if (treeSearchIsActive(query)) {
+            const { expandKeys } = matchingTreeKeysWithAncestors(tree.walk(), query);
+            setExpandedTreeKeys(Array.from(expandKeys));
+            setAutoExpandTreeParent(true);
+        }
+        setSearchValue(value);
+    };
+
     const onExpand = (newExpandedKeys: React.Key[]) => {
         setExpandedTreeKeys(newExpandedKeys as TreeKey[]);
         setAutoExpandTreeParent(false);
@@ -163,28 +205,22 @@ export default function Sider({
         setSelectedTreeKeys(keys);
     };
 
-    const onSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { value } = e.target;
-        const newExpandedKeys = new Set<TreeKey>();
-        for (const [node, parent] of tree.walk()) {
-            const strTitle = node.title as string;
-            if (strTitle.includes(value) && parent !== null) {
-                newExpandedKeys.add(parent.key);
-            }
+    const visibleRoots = useMemo(() => {
+        const roots = tree.getRoots();
+        if (!searchMatch) {
+            return roots;
         }
-        setExpandedTreeKeys(Array.from(newExpandedKeys));
-        setSearchValue(value);
-        setAutoExpandTreeParent(true);
-    };
+        return filterTreeToMatches(roots, searchMatch.matchKeys);
+    }, [tree, searchMatch]);
 
     const formattedTreeData = useMemo(() => {
         return treeTitleFormatter(
-            tree,
+            visibleRoots,
             searchNodeTitleFormatterFactory(searchValue),
             compareBadge,
             compareBadgeColors,
         );
-    }, [searchValue, tree, compareBadge, compareBadgeColors]);
+    }, [searchValue, visibleRoots, compareBadge, compareBadgeColors]);
 
     const onResizeMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
         if (!sidebarVisible) {
@@ -264,11 +300,41 @@ export default function Sider({
                 {...(!sidebarVisible ? { inert: "" } as any : {})}
             >
                 <div style={{ display: "flex", alignItems: "center" }}>
-                    <Input
-                        {...view.sider.search.props}
-                        onChange={onSearchChange}
-                        style={{ ...view.sider.search.props.style, flex: 1, minWidth: 0 }}
-                    />
+                    <AutoComplete
+                        value={searchValue}
+                        options={searchSuggestions.map((suggestion) => {
+                            const completed = applyTreeSearchSuggestion(
+                                searchValue,
+                                suggestion,
+                            );
+                            const labelText =
+                                suggestion.kind === "tag"
+                                    ? suggestion.value
+                                    : String(suggestion.value);
+                            const kindLabel = suggestion.kind === "tag" ? "tag:" : "tier:";
+                            return {
+                                value: completed,
+                                label: (
+                                    <span>
+                                        <span style={{ opacity: 0.65 }}>{kindLabel}</span>
+                                        {labelText}
+                                    </span>
+                                ),
+                            };
+                        })}
+                        onChange={(value) => applySearchValue(value ?? "")}
+                        filterOption={false}
+                        defaultActiveFirstOption={false}
+                        allowClear
+                        style={{ flex: 1, minWidth: 0 }}
+                    >
+                        <Input
+                            {...view.sider.search.props}
+                            placeholder="Search name, tag:…, tier:…"
+                            style={{ ...view.sider.search.props.style, width: "100%" }}
+                            aria-label="Search coverage tree by name, tag, or tier"
+                        />
+                    </AutoComplete>
                 </div>
                 <div style={{ flex: 1, overflowY: "auto", overflowX: "hidden" }}>
                     <AntTree

--- a/viewer/src/features/Dashboard/lib/treeSearch.test.ts
+++ b/viewer/src/features/Dashboard/lib/treeSearch.test.ts
@@ -1,0 +1,233 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+ */
+
+import { describe, expect, test } from "vitest";
+
+import type { TreeNode } from "./tree";
+import {
+    applyTagSuggestion,
+    applyTierSuggestion,
+    buildTreeSearchSuggestions,
+    collectTreeTags,
+    collectTreeTiers,
+    filterTreeToMatches,
+    matchingTreeKeysWithAncestors,
+    nodeMatchesTreeSearch,
+    parsePointTags,
+    parseTreeSearchQuery,
+    suggestTagsForPrefix,
+    suggestTiersForPrefix,
+    treeSearchIsActive,
+} from "./treeSearch";
+
+function pointNode(
+    key: string,
+    title: string,
+    opts: { tags?: string; tier?: number | null; children?: TreeNode[] } = {},
+): TreeNode {
+    return {
+        key,
+        title,
+        children: opts.children,
+        data: {
+            point: {
+                tags: opts.tags ?? "",
+                tier: opts.tier ?? null,
+            },
+        },
+    };
+}
+
+describe("parsePointTags", () => {
+    test("parses JSON and comma-separated tags", () => {
+        expect(parsePointTags('["uart","axi"]')).toEqual(["uart", "axi"]);
+        expect(parsePointTags("uart, axi")).toEqual(["uart", "axi"]);
+        expect(parsePointTags("")).toEqual([]);
+    });
+});
+
+describe("parseTreeSearchQuery", () => {
+    test("parses name terms with tag and tier keywords", () => {
+        expect(parseTreeSearchQuery("tag:flags tier:2 compare")).toEqual({
+            nameTerms: ["compare"],
+            tags: ["flags"],
+            tiers: [2],
+            tagPrefix: null,
+            tierPrefix: null,
+        });
+        expect(parseTreeSearchQuery("compare tag:flags tier:2 ")).toEqual({
+            nameTerms: ["compare"],
+            tags: ["flags"],
+            tiers: [2],
+            tagPrefix: null,
+            tierPrefix: null,
+        });
+    });
+
+    test("exposes trailing incomplete tag: and tier: as prefixes", () => {
+        expect(parseTreeSearchQuery("tag:fl")).toEqual({
+            nameTerms: [],
+            tags: [],
+            tiers: [],
+            tagPrefix: "fl",
+            tierPrefix: null,
+        });
+        expect(parseTreeSearchQuery("tier:1")).toEqual({
+            nameTerms: [],
+            tags: [],
+            tiers: [],
+            tagPrefix: null,
+            tierPrefix: "1",
+        });
+        expect(parseTreeSearchQuery("tier:1 tag:")).toEqual({
+            nameTerms: [],
+            tags: [],
+            tiers: [1],
+            tagPrefix: "",
+            tierPrefix: null,
+        });
+    });
+
+    test("completed tag tokens keep exact filters when spaced", () => {
+        expect(parseTreeSearchQuery("tag:flags ")).toEqual({
+            nameTerms: [],
+            tags: ["flags"],
+            tiers: [],
+            tagPrefix: null,
+            tierPrefix: null,
+        });
+    });
+});
+
+describe("nodeMatchesTreeSearch", () => {
+    const leaf = pointNode("p", "flag_generation", {
+        tags: '["compare","flags"]',
+        tier: 2,
+    });
+
+    test("matches name, tag, and tier together", () => {
+        expect(
+            nodeMatchesTreeSearch(leaf, parseTreeSearchQuery("flag tag:compare tier:2 ")),
+        ).toBe(true);
+        expect(nodeMatchesTreeSearch(leaf, parseTreeSearchQuery("tag:missing"))).toBe(
+            false,
+        );
+        expect(nodeMatchesTreeSearch(leaf, parseTreeSearchQuery("tier:1 "))).toBe(false);
+    });
+
+    test("soft-matches tag and tier prefixes while typing", () => {
+        expect(nodeMatchesTreeSearch(leaf, parseTreeSearchQuery("tag:fla"))).toBe(true);
+        expect(nodeMatchesTreeSearch(leaf, parseTreeSearchQuery("tag:xyz"))).toBe(false);
+        expect(nodeMatchesTreeSearch(leaf, parseTreeSearchQuery("tier:2"))).toBe(true);
+        expect(nodeMatchesTreeSearch(leaf, parseTreeSearchQuery("tier:9"))).toBe(false);
+    });
+});
+
+describe("suggestTagsForPrefix", () => {
+    test("prefers prefix hits and skips already selected tags", () => {
+        expect(
+            suggestTagsForPrefix(["compare", "flags", "control", "flow"], "f", [
+                "flags",
+            ]),
+        ).toEqual(["flow"]);
+        expect(suggestTagsForPrefix(["compare", "flags"], "ag")).toEqual(["flags"]);
+    });
+});
+
+describe("suggestTiersForPrefix", () => {
+    test("filters known tiers by prefix", () => {
+        expect(suggestTiersForPrefix([0, 1, 2, 12], "1")).toEqual([1, 12]);
+        expect(suggestTiersForPrefix([0, 1, 2], "", [1])).toEqual([0, 2]);
+    });
+});
+
+describe("apply suggestions", () => {
+    test("replaces trailing tag prefix or free text", () => {
+        expect(applyTagSuggestion("tag:fl", "flags")).toBe("tag:flags ");
+        expect(applyTagSuggestion("x tag:fl", "flags")).toBe("x tag:flags ");
+        expect(applyTagSuggestion("fla", "flags")).toBe("tag:flags ");
+        expect(applyTagSuggestion("compare fla", "flags")).toBe("compare tag:flags ");
+    });
+
+    test("replaces trailing tier prefix", () => {
+        expect(applyTierSuggestion("tier:1", 12)).toBe("tier:12 ");
+        expect(applyTierSuggestion("x tier:", 2)).toBe("x tier:2 ");
+    });
+});
+
+describe("buildTreeSearchSuggestions", () => {
+    const tags = ["compare", "flags", "control"];
+    const tiers = [0, 1, 2];
+
+    test("suggests tags for tag: and free text, tiers for tier:", () => {
+        expect(
+            buildTreeSearchSuggestions("tag:fl", parseTreeSearchQuery("tag:fl"), tags, tiers),
+        ).toEqual([{ kind: "tag", value: "flags" }]);
+
+        expect(
+            buildTreeSearchSuggestions("tier:", parseTreeSearchQuery("tier:"), tags, tiers),
+        ).toEqual([
+            { kind: "tier", value: 0 },
+            { kind: "tier", value: 1 },
+            { kind: "tier", value: 2 },
+        ]);
+
+        expect(
+            buildTreeSearchSuggestions("fla", parseTreeSearchQuery("fla"), tags, tiers),
+        ).toEqual([{ kind: "tag", value: "flags" }]);
+
+        expect(
+            buildTreeSearchSuggestions("2", parseTreeSearchQuery("2"), tags, tiers),
+        ).toEqual([{ kind: "tier", value: 2 }]);
+    });
+});
+
+describe("tree filter helpers", () => {
+    test("collects tags/tiers and prunes to matching paths", () => {
+        const root = pointNode("root", "StressTest", {
+            children: [
+                pointNode("g", "compare", {
+                    children: [
+                        pointNode("a", "flag_generation", {
+                            tags: '["flags"]',
+                            tier: 2,
+                        }),
+                        pointNode("b", "compare_operations", {
+                            tags: '["compare"]',
+                            tier: 1,
+                        }),
+                    ],
+                }),
+            ],
+        });
+
+        function* walk(
+            nodes: TreeNode[] = [root],
+            parent: TreeNode | null = null,
+        ): Generator<[TreeNode, TreeNode | null]> {
+            for (const node of nodes) {
+                yield [node, parent];
+                if (node.children) {
+                    yield* walk(node.children, node);
+                }
+            }
+        }
+
+        expect(collectTreeTags(walk())).toEqual(["compare", "flags"]);
+        expect(collectTreeTiers(walk())).toEqual([1, 2]);
+
+        const query = parseTreeSearchQuery("tag:flags ");
+        expect(treeSearchIsActive(query)).toBe(true);
+        const { matchKeys, expandKeys } = matchingTreeKeysWithAncestors(walk(), query);
+        expect(matchKeys.has("a")).toBe(true);
+        expect(matchKeys.has("b")).toBe(false);
+        expect(expandKeys.has("g")).toBe(true);
+        expect(expandKeys.has("root")).toBe(true);
+
+        const filtered = filterTreeToMatches([root], matchKeys);
+        expect(filtered).toHaveLength(1);
+        expect(filtered[0].children?.[0].children?.map((n) => n.key)).toEqual(["a"]);
+    });
+});

--- a/viewer/src/features/Dashboard/lib/treeSearch.ts
+++ b/viewer/src/features/Dashboard/lib/treeSearch.ts
@@ -1,0 +1,431 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+ */
+
+import type { TreeKey, TreeNode } from "./tree";
+
+/** Decode stored point tags: JSON array first, comma-separated fallback. */
+export function parsePointTags(tags: string | null | undefined): string[] {
+    if (!tags) {
+        return [];
+    }
+    try {
+        const decoded: unknown = JSON.parse(tags);
+        if (Array.isArray(decoded)) {
+            return decoded
+                .map((tag) => String(tag).trim())
+                .filter((tag) => tag.length > 0);
+        }
+    } catch {
+        // Fall back to legacy comma-separated format.
+    }
+    return tags
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter((tag) => tag.length > 0);
+}
+
+export type TreeSearchQuery = {
+    /** Free-text fragments matched against node titles (AND). */
+    nameTerms: string[];
+    /** Completed `tag:` values; node must carry every tag (case-insensitive). */
+    tags: string[];
+    /** Completed `tier:` values; node tier must be one of these. */
+    tiers: number[];
+    /**
+     * Incomplete `tag:<prefix>` at the end of the input (no trailing space).
+     * Used for autocomplete; also soft-filters tags that contain the prefix.
+     */
+    tagPrefix: string | null;
+    /**
+     * Incomplete `tier:<prefix>` at the end of the input (no trailing space).
+     * Used for autocomplete; also soft-filters matching tiers.
+     */
+    tierPrefix: string | null;
+};
+
+export type TreeSearchSuggestion =
+    | { kind: "tag"; value: string }
+    | { kind: "tier"; value: number };
+
+const KEYWORD_RE = /^(tag|tier):(.*)$/i;
+
+/**
+ * Parse coverage-tree search text.
+ *
+ * Keywords: `tag:name`, `tier:N`. Remaining tokens are name substrings.
+ * A trailing `tag:` / `tier:` / partial keyword (no space after) is exposed as
+ * a prefix for autocomplete.
+ */
+export function parseTreeSearchQuery(raw: string): TreeSearchQuery {
+    const empty: TreeSearchQuery = {
+        nameTerms: [],
+        tags: [],
+        tiers: [],
+        tagPrefix: null,
+        tierPrefix: null,
+    };
+    const trimmed = raw.trim();
+    if (!trimmed) {
+        return empty;
+    }
+
+    // A trailing space means the last token is complete (e.g. `tag:flags `).
+    const hasTrailingSpace = /\s$/.test(raw);
+    const tokens = trimmed.split(/\s+/);
+    const nameTerms: string[] = [];
+    const tags: string[] = [];
+    const tiers: number[] = [];
+    let tagPrefix: string | null = null;
+    let tierPrefix: string | null = null;
+
+    tokens.forEach((token, index) => {
+        const isLast = index === tokens.length - 1;
+        const keyword = token.match(KEYWORD_RE);
+        if (!keyword) {
+            nameTerms.push(token);
+            return;
+        }
+
+        const kind = keyword[1].toLowerCase();
+        const value = keyword[2];
+
+        if (kind === "tag") {
+            if (isLast && !hasTrailingSpace) {
+                tagPrefix = value;
+                return;
+            }
+            if (value.length > 0) {
+                tags.push(value);
+            }
+            return;
+        }
+
+        // tier:
+        if (isLast && !hasTrailingSpace) {
+            tierPrefix = value;
+            return;
+        }
+        if (value.length === 0) {
+            return;
+        }
+        const tier = Number(value);
+        if (!Number.isNaN(tier)) {
+            tiers.push(tier);
+        }
+    });
+
+    return { nameTerms, tags, tiers, tagPrefix, tierPrefix };
+}
+
+export function treeSearchIsActive(query: TreeSearchQuery): boolean {
+    return (
+        query.nameTerms.length > 0
+        || query.tags.length > 0
+        || query.tiers.length > 0
+        || (query.tagPrefix !== null && query.tagPrefix.length > 0)
+        || (query.tierPrefix !== null && query.tierPrefix.length > 0)
+    );
+}
+
+type PointLikeNode = TreeNode<{
+    point?: { tags?: string | null; tier?: number | null };
+}>;
+
+function nodeTitle(node: TreeNode): string {
+    return typeof node.title === "string" ? node.title : String(node.title ?? "");
+}
+
+function nodeTags(node: PointLikeNode): string[] {
+    return parsePointTags(node.data?.point?.tags);
+}
+
+function nodeTier(node: PointLikeNode): number | null {
+    const tier = node.data?.point?.tier;
+    if (tier === null || tier === undefined || Number.isNaN(tier)) {
+        return null;
+    }
+    return tier;
+}
+
+function tagEquals(a: string, b: string): boolean {
+    return a.localeCompare(b, undefined, { sensitivity: "accent" }) === 0;
+}
+
+function tagIncludes(tag: string, needle: string): boolean {
+    return tag.toLocaleLowerCase().includes(needle.toLocaleLowerCase());
+}
+
+function tierMatchesPrefix(tier: number, prefix: string): boolean {
+    if (prefix.length === 0) {
+        return true;
+    }
+    return String(tier).includes(prefix);
+}
+
+/** Whether this node itself satisfies the parsed query (not via descendants). */
+export function nodeMatchesTreeSearch(node: PointLikeNode, query: TreeSearchQuery): boolean {
+    if (!treeSearchIsActive(query)) {
+        return true;
+    }
+
+    const title = nodeTitle(node);
+    for (const term of query.nameTerms) {
+        if (!title.includes(term)) {
+            return false;
+        }
+    }
+
+    const tags = nodeTags(node);
+    for (const required of query.tags) {
+        if (!tags.some((tag) => tagEquals(tag, required))) {
+            return false;
+        }
+    }
+
+    if (query.tagPrefix !== null && query.tagPrefix.length > 0) {
+        if (!tags.some((tag) => tagIncludes(tag, query.tagPrefix!))) {
+            return false;
+        }
+    }
+
+    const tier = nodeTier(node);
+    if (query.tiers.length > 0) {
+        if (tier === null || !query.tiers.includes(tier)) {
+            return false;
+        }
+    }
+
+    if (query.tierPrefix !== null && query.tierPrefix.length > 0) {
+        if (tier === null || !tierMatchesPrefix(tier, query.tierPrefix)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Suggest tags for a partial prefix. Prefer prefix matches, then substring
+ * matches; exact completed tags already in the query are omitted.
+ */
+export function suggestTagsForPrefix(
+    allTags: Iterable<string>,
+    prefix: string,
+    alreadySelected: string[] = [],
+    limit = 8,
+): string[] {
+    const selected = new Set(alreadySelected.map((t) => t.toLocaleLowerCase()));
+    const needle = prefix.toLocaleLowerCase();
+    const prefixHits: string[] = [];
+    const containsHits: string[] = [];
+
+    const unique = Array.from(
+        new Map(Array.from(allTags, (tag) => [tag.toLocaleLowerCase(), tag])).values(),
+    ).sort((a, b) => a.localeCompare(b));
+
+    for (const tag of unique) {
+        const lower = tag.toLocaleLowerCase();
+        if (selected.has(lower)) {
+            continue;
+        }
+        if (needle.length === 0) {
+            prefixHits.push(tag);
+            continue;
+        }
+        if (lower.startsWith(needle)) {
+            prefixHits.push(tag);
+        } else if (lower.includes(needle)) {
+            containsHits.push(tag);
+        }
+    }
+
+    return [...prefixHits, ...containsHits].slice(0, limit);
+}
+
+/** Suggest known tiers whose string form matches the prefix. */
+export function suggestTiersForPrefix(
+    allTiers: Iterable<number>,
+    prefix: string,
+    alreadySelected: number[] = [],
+    limit = 8,
+): number[] {
+    const selected = new Set(alreadySelected);
+    const sorted = Array.from(new Set(allTiers))
+        .filter((tier) => !selected.has(tier))
+        .sort((a, b) => a - b);
+
+    if (prefix.length === 0) {
+        return sorted.slice(0, limit);
+    }
+
+    return sorted.filter((tier) => String(tier).includes(prefix)).slice(0, limit);
+}
+
+/** Replace a trailing `tag:<prefix>` or free-text token with `tag:<tag> `. */
+export function applyTagSuggestion(raw: string, tag: string): string {
+    const tagMatch = raw.match(/^(.*?)(tag:)([^\s]*)$/i);
+    if (tagMatch) {
+        return `${tagMatch[1]}${tagMatch[2]}${tag} `;
+    }
+    // Typing normally: replace the trailing free-text token with a tag filter.
+    const freeMatch = raw.match(/^(.*?)([^\s]+)$/);
+    if (freeMatch && !KEYWORD_RE.test(freeMatch[2])) {
+        return `${freeMatch[1]}tag:${tag} `;
+    }
+    const base = raw.replace(/\s+$/, "");
+    return base.length > 0 ? `${base} tag:${tag} ` : `tag:${tag} `;
+}
+
+/** Replace a trailing `tier:<prefix>` with `tier:<n> `, or append after free text. */
+export function applyTierSuggestion(raw: string, tier: number): string {
+    const tierMatch = raw.match(/^(.*?)(tier:)([^\s]*)$/i);
+    if (tierMatch) {
+        return `${tierMatch[1]}${tierMatch[2]}${tier} `;
+    }
+    const freeMatch = raw.match(/^(.*?)([^\s]+)$/);
+    if (freeMatch && !KEYWORD_RE.test(freeMatch[2])) {
+        return `${freeMatch[1]}tier:${tier} `;
+    }
+    const base = raw.replace(/\s+$/, "");
+    return base.length > 0 ? `${base} tier:${tier} ` : `tier:${tier} `;
+}
+
+/**
+ * Build clickable autocomplete options for the current input.
+ *
+ * - `tag:…` → matching tags
+ * - `tier:…` → matching tiers
+ * - plain typing → matching tags (and tiers when the token looks numeric)
+ */
+export function buildTreeSearchSuggestions(
+    raw: string,
+    query: TreeSearchQuery,
+    allTags: Iterable<string>,
+    allTiers: Iterable<number>,
+    limit = 8,
+): TreeSearchSuggestion[] {
+    if (query.tagPrefix !== null) {
+        return suggestTagsForPrefix(allTags, query.tagPrefix, query.tags, limit).map(
+            (value) => ({ kind: "tag" as const, value }),
+        );
+    }
+
+    if (query.tierPrefix !== null) {
+        return suggestTiersForPrefix(allTiers, query.tierPrefix, query.tiers, limit).map(
+            (value) => ({ kind: "tier" as const, value }),
+        );
+    }
+
+    // Plain typing: suggest from the trailing free-text token.
+    if (/\s$/.test(raw) || query.nameTerms.length === 0) {
+        return [];
+    }
+    const needle = query.nameTerms[query.nameTerms.length - 1] ?? "";
+    if (needle.length === 0) {
+        return [];
+    }
+
+    const suggestions: TreeSearchSuggestion[] = [];
+    const tagHits = suggestTagsForPrefix(allTags, needle, query.tags, limit);
+    for (const value of tagHits) {
+        suggestions.push({ kind: "tag", value });
+    }
+
+    if (/^\d+$/.test(needle)) {
+        const remaining = Math.max(0, limit - suggestions.length);
+        for (const value of suggestTiersForPrefix(allTiers, needle, query.tiers, remaining)) {
+            suggestions.push({ kind: "tier", value });
+        }
+    }
+
+    return suggestions.slice(0, limit);
+}
+
+export function applyTreeSearchSuggestion(
+    raw: string,
+    suggestion: TreeSearchSuggestion,
+): string {
+    return suggestion.kind === "tag"
+        ? applyTagSuggestion(raw, suggestion.value)
+        : applyTierSuggestion(raw, suggestion.value);
+}
+
+/** Collect every distinct tag on coverpoints in the tree. */
+export function collectTreeTags(walk: Iterable<[TreeNode, TreeNode | null]>): string[] {
+    const byLower = new Map<string, string>();
+    for (const [node] of walk) {
+        for (const tag of nodeTags(node as PointLikeNode)) {
+            const key = tag.toLocaleLowerCase();
+            if (!byLower.has(key)) {
+                byLower.set(key, tag);
+            }
+        }
+    }
+    return Array.from(byLower.values()).sort((a, b) => a.localeCompare(b));
+}
+
+/** Collect every distinct tier on coverpoints in the tree. */
+export function collectTreeTiers(walk: Iterable<[TreeNode, TreeNode | null]>): number[] {
+    const tiers = new Set<number>();
+    for (const [node] of walk) {
+        const tier = nodeTier(node as PointLikeNode);
+        if (tier !== null) {
+            tiers.add(tier);
+        }
+    }
+    return Array.from(tiers).sort((a, b) => a - b);
+}
+
+/**
+ * Keys of nodes that match, plus every ancestor key so the path stays visible
+ * when the tree is pruned.
+ */
+export function matchingTreeKeysWithAncestors(
+    walk: Iterable<[TreeNode, TreeNode | null]>,
+    query: TreeSearchQuery,
+): { matchKeys: Set<TreeKey>; expandKeys: Set<TreeKey> } {
+    const matchKeys = new Set<TreeKey>();
+    const expandKeys = new Set<TreeKey>();
+    const parentByKey = new Map<TreeKey, TreeKey | null>();
+
+    for (const [node, parent] of walk) {
+        parentByKey.set(node.key, parent?.key ?? null);
+        if (nodeMatchesTreeSearch(node as PointLikeNode, query)) {
+            matchKeys.add(node.key);
+        }
+    }
+
+    for (const key of matchKeys) {
+        let parent = parentByKey.get(key) ?? null;
+        while (parent !== null) {
+            expandKeys.add(parent);
+            parent = parentByKey.get(parent) ?? null;
+        }
+    }
+
+    return { matchKeys, expandKeys };
+}
+
+/** Keep nodes that match or have a matching descendant. */
+export function filterTreeToMatches<T>(
+    nodes: TreeNode<T>[],
+    matchKeys: Set<TreeKey>,
+): TreeNode<T>[] {
+    const filterNodes = (list: TreeNode<T>[]): TreeNode<T>[] => {
+        const out: TreeNode<T>[] = [];
+        for (const node of list) {
+            const children = node.children ? filterNodes(node.children as TreeNode<T>[]) : undefined;
+            const selfMatch = matchKeys.has(node.key);
+            if (selfMatch || (children && children.length > 0)) {
+                out.push({
+                    ...node,
+                    children: children && children.length > 0 ? children : node.children?.length ? [] : undefined,
+                });
+            }
+        }
+        return out;
+    };
+    return filterNodes(nodes);
+}

--- a/viewer/src/features/Dashboard/theme.tsx
+++ b/viewer/src/features/Dashboard/theme.tsx
@@ -46,7 +46,7 @@ const sider = {
     } as SiderProps,
     search: {
         props: {
-            placeholder: "Search coverage tree…",
+            placeholder: "Search name, tag:…, tier:…",
             variant: "outlined",
         } as SearchProps,
     },


### PR DESCRIPTION
## Summary
- Coverage tree search accepts `tag:name` and `tier:N`, and prunes the tree to matching coverpoints and their ancestors.
- Autocomplete suggests tags for `tag:…`, tiers for `tier:…`, and matching tags while typing plain text (numeric tokens also suggest tiers).
- Documents the new search keywords in the viewing coverage guide.

## Test plan
- [ ] Load example (or other tagged) coverage and type `tag:` — confirm clickable tag suggestions appear and complete the query
- [ ] Type `tier:` — confirm tier suggestions; selecting one filters to that tier
- [ ] Type a partial tag name without a keyword (e.g. `fla`) — confirm tag suggestions still appear
- [ ] Type a bare tier digit that exists in the data — confirm a `tier:` suggestion
- [ ] Confirm name-only search still highlights and prunes matching paths
- [ ] `cd viewer && npm test -- --run src/features/Dashboard/lib/treeSearch.test.ts`