### PR TITLE
[Patch] Sync completed tag:/tier: tree search into Summary filters

### DIFF
--- a/docs/viewing_coverage.md
+++ b/docs/viewing_coverage.md
@@ -174,6 +174,8 @@ The coverage tree search box matches point names and also accepts keywords:
 as clickable suggestions. Plain typing also suggests matching tags (and tiers when
 the token is numeric); choosing a suggestion inserts the `tag:` / `tier:` filter.
 Active search prunes the tree to matching coverpoints and their ancestors.
+Completed `tag:` / `tier:` keywords also drive the Summary table’s Tier and Tags
+column filters (name-only search stays tree-only).
 
 Selecting a coverpoint shows its buckets, goals, hit counts, and hit percentage.
 Axis columns and goal names can be filtered; columns can be sorted. Summary views

--- a/viewer/src/features/Dashboard/components/Sider/index.tsx
+++ b/viewer/src/features/Dashboard/components/Sider/index.tsx
@@ -114,6 +114,8 @@ export type SiderProps = {
     selectedTreeKeys: TreeKey[];
     expandedTreeKeys: TreeKey[];
     autoExpandTreeParent: boolean;
+    searchValue: string;
+    onSearchValueChange: (value: string) => void;
     setSidebarWidth: (width: number) => void;
     setAutoExpandTreeParent: (newValue: boolean) => void;
     setSelectedTreeKeys: (newSelectedKeys: TreeKey[]) => void;
@@ -128,6 +130,8 @@ export default function Sider({
     selectedTreeKeys,
     expandedTreeKeys,
     autoExpandTreeParent,
+    searchValue,
+    onSearchValueChange,
     setSidebarWidth,
     setAutoExpandTreeParent,
     setSelectedTreeKeys,
@@ -135,7 +139,6 @@ export default function Sider({
     compareBadge,
 }: SiderProps) {
     const { theme } = Theme.useContext();
-    const [searchValue, setSearchValue] = useState("");
     const [isResizing, setIsResizing] = useState(false);
     const resizeStateRef = useRef<{ startX: number; startWidth: number } | null>(null);
 
@@ -173,7 +176,7 @@ export default function Sider({
             setExpandedTreeKeys(Array.from(expandKeys));
             setAutoExpandTreeParent(true);
         }
-        setSearchValue(value);
+        onSearchValueChange(value);
     };
 
     const onExpand = (newExpandedKeys: React.Key[]) => {

--- a/viewer/src/features/Dashboard/index.tsx
+++ b/viewer/src/features/Dashboard/index.tsx
@@ -814,6 +814,7 @@ export default function Dashboard({
         {} as { [key: TreeKey]: string | number },
     );
     const [summaryViewMode, setSummaryViewMode] = useState<"table" | "donut">("table");
+    const [treeSearchValue, setTreeSearchValue] = useState("");
     const [editModalOpen, setEditModalOpen] = useState(false);
     const [editLoadedById, setEditLoadedById] = useState<Record<string, boolean>>({});
     const [mergeSelectedIds, setMergeSelectedIds] = useState<string[]>([]);
@@ -966,6 +967,7 @@ export default function Dashboard({
         if (isEmpty) {
             navigationPastRef.current = [];
             setViewNavigationPastLength(0);
+            setTreeSearchValue("");
             if (selectedTreeKeys.length > 0) {
                 setSelectedTreeKeys([]);
                 setExpandedTreeKeys([]);
@@ -1179,6 +1181,7 @@ export default function Dashboard({
                         node={currentNode}
                         setSelectedTreeKeys={onSelect}
                         compare={compareContext}
+                        treeSearchValue={treeSearchValue}
                     />
                 );
                 return withTopLevelInfoPanel({
@@ -1206,6 +1209,7 @@ export default function Dashboard({
         logoSrc,
         isDragging,
         summaryViewMode,
+        treeSearchValue,
         onSelect,
         topLevelCoverageInfo,
         compareContext,
@@ -1321,6 +1325,8 @@ export default function Dashboard({
                                     setSidebarWidth={setSidebarWidth}
                                     autoExpandTreeParent={autoExpandTreeParent}
                                     setAutoExpandTreeParent={setAutoExpandTreeParent}
+                                    searchValue={treeSearchValue}
+                                    onSearchValueChange={setTreeSearchValue}
                                     compareBadge={compareContext ? compareTreeBadge : undefined}
                                 />
                             )}

--- a/viewer/src/features/Dashboard/lib/coveragegrid.tsx
+++ b/viewer/src/features/Dashboard/lib/coveragegrid.tsx
@@ -6,6 +6,10 @@
 import CoverageTree, { PointNode } from "./coveragetree";
 import { getPointNodeCompareCounts, getPointNodeCoverageMetrics } from "./coveragemetrics";
 import {
+    parseTreeSearchQuery,
+    summaryFiltersFromTreeSearch,
+} from "./treeSearch";
+import {
     Alert,
     Button,
     Checkbox,
@@ -53,6 +57,7 @@ import {
     useCallback,
     useEffect,
     useMemo,
+    useRef,
     useState,
 } from "react";
 import {
@@ -2029,6 +2034,8 @@ export type PointSummaryGridProps = {
     node: PointNode;
     setSelectedTreeKeys: (newSelectedKeys: TreeKey[]) => void;
     compare?: CompareViewContext;
+    /** Sidebar tree search text; completed tag:/tier: keywords drive table filters. */
+    treeSearchValue?: string;
 };
 
 function createInitialExpandedSet(tree: CoverageTree, node: PointNode): Set<TreeKey> {
@@ -2051,6 +2058,7 @@ export function PointSummaryGrid({
     node,
     setSelectedTreeKeys,
     compare,
+    treeSearchValue = "",
 }: PointSummaryGridProps) {
     const [expandedCovergroups, setExpandedCovergroups] = useState<Set<TreeKey>>(() =>
         createInitialExpandedSet(tree, node),
@@ -2058,15 +2066,48 @@ export function PointSummaryGrid({
     const [selectedTiers, setSelectedTiers] = useState<number[]>([]);
     const [selectedTags, setSelectedTags] = useState<string[]>([]);
     const [tagMatchMode, setTagMatchMode] = useState<SummaryTagMatchMode>("any");
+    const treeSearchDrivesFiltersRef = useRef(false);
 
     useEffect(() => {
         setExpandedCovergroups(createInitialExpandedSet(tree, node));
     }, [tree, node]);
 
+    // Completed tag:/tier: keywords in the sidebar search drive Summary filters.
     useEffect(() => {
+        const fromSearch = summaryFiltersFromTreeSearch(
+            parseTreeSearchQuery(treeSearchValue),
+        );
+        if (fromSearch.drives) {
+            treeSearchDrivesFiltersRef.current = true;
+            setSelectedTiers(fromSearch.tiers);
+            setSelectedTags(fromSearch.tags);
+            setTagMatchMode(fromSearch.tagMatchMode);
+            return;
+        }
+        if (treeSearchDrivesFiltersRef.current) {
+            treeSearchDrivesFiltersRef.current = false;
+            setSelectedTiers([]);
+            setSelectedTags([]);
+            setTagMatchMode("any");
+        }
+    }, [treeSearchValue]);
+
+    useEffect(() => {
+        const fromSearch = summaryFiltersFromTreeSearch(
+            parseTreeSearchQuery(treeSearchValue),
+        );
+        if (fromSearch.drives) {
+            treeSearchDrivesFiltersRef.current = true;
+            setSelectedTiers(fromSearch.tiers);
+            setSelectedTags(fromSearch.tags);
+            setTagMatchMode(fromSearch.tagMatchMode);
+            return;
+        }
         setSelectedTiers([]);
         setSelectedTags([]);
         setTagMatchMode("any");
+        // Intentionally omit treeSearchValue: name-only edits must not reset filters.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [tree, node.key]);
 
     const toggleCovergroup = (key: TreeKey, e: MouseEvent) => {

--- a/viewer/src/features/Dashboard/lib/treeSearch.test.ts
+++ b/viewer/src/features/Dashboard/lib/treeSearch.test.ts
@@ -19,6 +19,7 @@ import {
     parseTreeSearchQuery,
     suggestTagsForPrefix,
     suggestTiersForPrefix,
+    summaryFiltersFromTreeSearch,
     treeSearchIsActive,
 } from "./treeSearch";
 
@@ -45,6 +46,41 @@ describe("parsePointTags", () => {
         expect(parsePointTags('["uart","axi"]')).toEqual(["uart", "axi"]);
         expect(parsePointTags("uart, axi")).toEqual(["uart", "axi"]);
         expect(parsePointTags("")).toEqual([]);
+    });
+});
+
+describe("summaryFiltersFromTreeSearch", () => {
+    test("drives Summary filters from completed tag/tier keywords only", () => {
+        expect(summaryFiltersFromTreeSearch(parseTreeSearchQuery("compare"))).toEqual({
+            drives: false,
+            tags: [],
+            tiers: [],
+            tagMatchMode: "any",
+        });
+        expect(summaryFiltersFromTreeSearch(parseTreeSearchQuery("tag:fl"))).toEqual({
+            drives: false,
+            tags: [],
+            tiers: [],
+            tagMatchMode: "any",
+        });
+        expect(
+            summaryFiltersFromTreeSearch(parseTreeSearchQuery("tag:flags tier:2 ")),
+        ).toEqual({
+            drives: true,
+            tags: ["flags"],
+            tiers: [2],
+            tagMatchMode: "any",
+        });
+        expect(
+            summaryFiltersFromTreeSearch(
+                parseTreeSearchQuery("tag:flags tag:compare "),
+            ),
+        ).toEqual({
+            drives: true,
+            tags: ["flags", "compare"],
+            tiers: [],
+            tagMatchMode: "all",
+        });
     });
 });
 

--- a/viewer/src/features/Dashboard/lib/treeSearch.ts
+++ b/viewer/src/features/Dashboard/lib/treeSearch.ts
@@ -129,6 +129,33 @@ export function treeSearchIsActive(query: TreeSearchQuery): boolean {
     );
 }
 
+export type SummaryTagMatchMode = "any" | "all";
+
+/**
+ * Completed `tag:` / `tier:` keywords that should drive the Summary table
+ * filters. Incomplete prefixes stay tree-only until accepted/spaced.
+ */
+export type SummaryFiltersFromTreeSearch = {
+    /** When true, Summary Tier/Tags filters follow the tree search keywords. */
+    drives: boolean;
+    tags: string[];
+    tiers: number[];
+    tagMatchMode: SummaryTagMatchMode;
+};
+
+export function summaryFiltersFromTreeSearch(
+    query: TreeSearchQuery,
+): SummaryFiltersFromTreeSearch {
+    const drives = query.tags.length > 0 || query.tiers.length > 0;
+    return {
+        drives,
+        tags: [...query.tags],
+        tiers: [...query.tiers],
+        // Tree search requires every completed tag; mirror that with All.
+        tagMatchMode: query.tags.length > 1 ? "all" : "any",
+    };
+}
+
 type PointLikeNode = TreeNode<{
     point?: { tags?: string | null; tier?: number | null };
 }>;


### PR DESCRIPTION
## Summary
- Completed `tag:` / `tier:` keywords in the coverage tree search now drive the Summary table’s Tier and Tags filters (multi-tag uses All).
- Name-only search still only affects the tree; clearing keyword filters clears the search-driven Summary filters.
- Documents the sync behavior in the viewing coverage guide.

## Test plan
- [ ] Load example data, open Summary, type `tag:compare ` (trailing space or autocomplete) — Summary Tags filter should select `compare`
- [ ] Add `tier:1 ` — Tier filter should also select 1
- [ ] Name-only search (e.g. `flag`) should not change Summary Tier/Tags filters
- [ ] Clear the search box after keyword filters — Summary Tier/Tags filters clear
- [ ] Manually set table filters, then name-search — table filters should remain
- [ ] `cd viewer && npm test -- --run src/features/Dashboard/lib/treeSearch.test.ts`