### PR TITLE
[Patch] Scope compare summary stats to the selected coverpoint

### DIFF
--- a/viewer/src/features/Dashboard/components/CompareToolbar/index.tsx
+++ b/viewer/src/features/Dashboard/components/CompareToolbar/index.tsx
@@ -15,12 +15,15 @@ import {
 } from "@/utils/colors";
 import type { UseCoverageCompareResult } from "@/hooks/useCoverageCompare";
 import type { CompareRecordRow } from "@/hooks/useCoverageCompare";
+import type { CategoryCounts } from "@/types/coverageCompare";
 import CompareReportExportModal from "@/features/Dashboard/components/CompareReportExportModal";
 
 export type CompareToolbarProps = {
     compare: UseCoverageCompareResult;
     records: CompareRecordRow[];
     onClose: () => void;
+    /** When set (e.g. active coverpoint/covergroup), cards use these instead of global. */
+    summaryCounts?: CategoryCounts;
 };
 
 function SummaryStat({
@@ -92,7 +95,12 @@ function SummaryStat({
     );
 }
 
-export default function CompareToolbar({ compare, records, onClose }: CompareToolbarProps) {
+export default function CompareToolbar({
+    compare,
+    records,
+    onClose,
+    summaryCounts,
+}: CompareToolbarProps) {
     const compatibleRecords = records.filter((record) =>
         compare.compatibleRecordIds.includes(record.id),
     );
@@ -104,8 +112,8 @@ export default function CompareToolbar({ compare, records, onClose }: CompareToo
     const [exportOpen, setExportOpen] = useState(false);
     const [exporting, setExporting] = useState(false);
 
-    const global = compare.comparison?.global;
-    const valid = global?.valid ?? 0;
+    const counts = summaryCounts ?? compare.comparison?.global;
+    const valid = counts?.valid ?? 0;
 
     return (
         <Theme.Consumer>
@@ -217,29 +225,29 @@ export default function CompareToolbar({ compare, records, onClose }: CompareToo
                                     {compare.comparisonError}
                                 </Typography.Text>
                             )}
-                            {global && (
+                            {counts && (
                                 <Flex gap="small" wrap="wrap" style={{ marginTop: 12 }}>
                                     <SummaryStat
                                         label="A only"
-                                        count={global.a_only}
+                                        count={counts.a_only}
                                         valid={valid}
                                         category="a_only"
                                     />
                                     <SummaryStat
                                         label="Both"
-                                        count={global.both}
+                                        count={counts.both}
                                         valid={valid}
                                         category="both"
                                     />
                                     <SummaryStat
                                         label="B only"
-                                        count={global.b_only}
+                                        count={counts.b_only}
                                         valid={valid}
                                         category="b_only"
                                     />
                                     <SummaryStat
                                         label="Neither"
-                                        count={global.neither}
+                                        count={counts.neither}
                                         valid={valid}
                                         category="neither"
                                     />

--- a/viewer/src/features/Dashboard/index.tsx
+++ b/viewer/src/features/Dashboard/index.tsx
@@ -1109,6 +1109,31 @@ export default function Dashboard({
         [compareContext],
     );
 
+    const compareToolbarCounts = useMemo(() => {
+        const comparison = compare?.comparison;
+        if (!comparison) {
+            return undefined;
+        }
+        if (viewKey === Tree.ROOT) {
+            return comparison.global;
+        }
+        const node = tree.getNodeByKey(viewKey);
+        if (!node) {
+            return comparison.global;
+        }
+        return (
+            getPointNodeCompareCounts(node as PointNode, comparison) ?? {
+                a_only: 0,
+                both: 0,
+                b_only: 0,
+                neither: 0,
+                valid: 0,
+                illegal: 0,
+                ignore: 0,
+            }
+        );
+    }, [compare?.comparison, tree, viewKey]);
+
     const isElectronProduction =
         typeof window !== "undefined" && window.location.protocol === "app:";
     const isFileProtocol =
@@ -1652,6 +1677,7 @@ export default function Dashboard({
                                         compare={compare}
                                         records={compareRecordRows}
                                         onClose={() => compare.setActive(false)}
+                                        summaryCounts={compareToolbarCounts}
                                     />
                                 )}
                                 <CoverageReportExportModal


### PR DESCRIPTION
## Summary
- Compare mode summary cards (A only / Both / B only / Neither / Valid buckets) now use counts for the selected coverpoint or covergroup
- At tree root they still show dataset-wide totals, matching previous behavior

## Test plan
- [ ] Enter Compare mode with two records
- [ ] At root, confirm summary cards match whole-dataset totals
- [ ] Select a coverpoint (e.g. `bitwise_operations`) and confirm cards update to that node's counts (aligned with the table)
- [ ] Select a covergroup and confirm cards sum descendant coverpoints
- [ ] Exit/re-enter compare and switch A/B records; cards stay scoped to the selection