### PR TITLE
[Patch] Take archive record offsets from the byte buffer

### DIFF
--- a/bucket/rw/archive.py
+++ b/bucket/rw/archive.py
@@ -79,13 +79,18 @@ def _write(path: Path, values: Iterable[tuple]):
     # Explicit UTF-8: the readers decode bytes as UTF-8, and Windows would
     # otherwise write the platform code page.
     with path.open("a", newline="", encoding="utf-8") as f:
-        byte_offset = f.tell()
+        # The readers seek with these offsets in binary mode, so take them from
+        # the underlying byte buffer: a text stream's tell() is only documented
+        # as an opaque cookie, even though it matches at line boundaries.
+        f.flush()
+        byte_offset = f.buffer.tell()
         csv_writer = csv.writer(f, quoting=csv.QUOTE_NONNUMERIC)
         for value in values:
             # Convert None values to empty strings for CSV compatibility
             csv_row = tuple("" if v is None else v for v in value)
             csv_writer.writerow(csv_row)
-        byte_end = f.tell()
+        f.flush()
+        byte_end = f.buffer.tell()
     return byte_offset, byte_end
 
 
@@ -399,8 +404,9 @@ class ArchiveReader(Reader):
         Read all records in the archive.
         """
         path, tempdir = self._extract()
-        # Record ids in the record file are start byte of each line
-        with (path / RECORD_PATH).open("r", newline="", encoding="utf-8") as f:
+        # Record ids in the record file are the start byte of each line. Binary
+        # mode so tell() is an exact byte offset; the line text is not needed.
+        with (path / RECORD_PATH).open("rb") as f:
             while True:
                 pos = f.tell()
                 if not f.readline():


### PR DESCRIPTION
## Summary
- `_write` now flushes and reads `f.buffer.tell()` for the start and end offsets instead of the text layer's `tell()`. The readers seek with these values in binary mode, so they should be byte positions by contract rather than by CPython's cookie behaviour at line boundaries.
- `read_all` opens the record file in binary mode, since it only needs each line's start position, not decoded text.
- No change to the on-disk archive format. Follow-up to the automated review comment on #207.

## Test plan
- [x] `uv run pytest` passes locally, including the archive round-trip and multi-record offset tests with non-ASCII descriptions
- [ ] CI green on Ubuntu and Windows
- [ ] Open an existing `.bktgz` (e.g. `example_regr_file_store.bktgz`) in the viewer and confirm all records still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
