### PR TITLE
[Patch] Reject duplicate axis names in add_axis

### DIFF
--- a/bucket/axis.py
+++ b/bucket/axis.py
@@ -47,6 +47,10 @@ class AxisAmbiguousValues(AxisException):
     pass
 
 
+class AxisNameAlreadyInUse(AxisException):
+    pass
+
+
 class AxisLookupMode(Enum):
     GENERIC = auto()
     SCALAR_ONLY = auto()

--- a/bucket/coverpoint.py
+++ b/bucket/coverpoint.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Callable
 
 from pydantic import validate_call
 
-from .axis import Axis
+from .axis import Axis, AxisNameAlreadyInUse
 from .base import CoverBase
 from .bucket import Bucket
 from .common.chain import Link, OpenLink
@@ -91,7 +91,8 @@ class Coverpoint(CoverBase):
         self.error = log.error
 
         # List of axes used by this coverpoint
-        self._axes: list[Axis] = []  # TODO make a dict
+        # Axes in definition order (bucket index order); names are unique
+        self._axes: list[Axis] = []
         # Hit count per bucket, indexed in itertools.product order
         self._hits: list[int] = []
         # Dictionary of defined goals
@@ -239,6 +240,12 @@ class Coverpoint(CoverBase):
         """
         Add axis with values to process later
         """
+        if any(axis.name == name for axis in self._axes):
+            # add_axis runs inside setup(), before _name is assigned
+            owner = getattr(self, "_name", None) or type(self).__name__
+            raise AxisNameAlreadyInUse(
+                f"Coverpoint '{owner}' already has an axis named '{name}'"
+            )
         self._axes.append(Axis(name, values, description, enable_other))
 
     @validate_call

--- a/tests/test_coverpoint_axis_names.py
+++ b/tests/test_coverpoint_axis_names.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Noodle-Bytes. All Rights Reserved
+
+import pytest
+
+from bucket import Covergroup, Coverpoint, Covertop
+from bucket.axis import AxisNameAlreadyInUse
+
+
+class DuplicateAxisPoint(Coverpoint):
+    def setup(self, ctx):
+        self.add_axis("value", values=[0, 1], description="First")
+        self.add_axis("value", values=[2, 3], description="Second, same name")
+
+    def sample(self, trace):
+        pass
+
+
+class DistinctAxesPoint(Coverpoint):
+    def setup(self, ctx):
+        self.add_axis("value", values=[0, 1], description="First")
+        self.add_axis("other", values=[2, 3], description="Second")
+
+    def sample(self, trace):
+        self.bucket.hit(value=trace["value"], other=trace["other"])
+
+
+class Group(Covergroup):
+    NAME = "group"
+
+    def setup(self, ctx):
+        self.add_coverpoint(DuplicateAxisPoint(), name="dup")
+
+
+class Top(Covertop):
+    NAME = "top"
+
+    def setup(self, ctx):
+        self.add_covergroup(Group())
+
+
+def test_duplicate_axis_name_is_rejected_at_setup():
+    with pytest.raises(AxisNameAlreadyInUse) as excinfo:
+        Top()
+    message = str(excinfo.value)
+    assert "DuplicateAxisPoint" in message
+    assert "'value'" in message
+
+
+def test_distinct_axis_names_are_accepted():
+    class LocalTop(Covertop):
+        NAME = "top"
+
+        def setup(self, ctx):
+            self.add_coverpoint(DistinctAxesPoint(), name="distinct")
+
+    top = LocalTop()
+    top.sample({"value": 1, "other": 3})
+    assert [axis.name for axis in top.distinct._axes] == ["value", "other"]
+    assert sum(top.distinct._hits) == 1


### PR DESCRIPTION
Two axes with the same name both entered the hit spec, so the second silently shadowed the first in hit(**kwargs) and half the buckets could never be reached. Raise AxisNameAlreadyInUse at setup instead, and drop the stale 'make a dict' TODO: the list is deliberate (definition order is bucket index order) and uniqueness is now enforced.