### PR TITLE
[None] Dependabot [None] titles and ignore blocked majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,21 +4,37 @@
 # Weekly dependency updates. Minor and patch bumps are grouped into one PR per
 # ecosystem so the alert backlog does not turn into dozens of PRs; majors and
 # security fixes still arrive individually.
+#
+# All Dependabot PRs use a [None] title prefix: dependency bumps do not cut a
+# Bucket tool release (see .github/RELEASE_AUTOMATION.md). Trailing whitespace
+# on the prefix prevents Dependabot from inserting a colon.
 version: 2
 updates:
   - package-ecosystem: npm
     directory: /viewer
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "[None] "
     groups:
       viewer-minor-and-patch:
         patterns: ["*"]
         update-types: [minor, patch]
+    # Majors blocked until peer deps catch up (see closed PRs #222–#224).
+    ignore:
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "antd"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: npm
     directory: /electron
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "[None] "
     groups:
       electron-minor-and-patch:
         patterns: ["*"]
@@ -28,6 +44,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "[None] "
     groups:
       python-minor-and-patch:
         patterns: ["*"]
@@ -37,3 +55,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "[None] "


### PR DESCRIPTION
## Summary
- Teach Dependabot to prefix commit/PR titles with `[None] ` so the PR title check passes without manual edits.
- Ignore major bumps of `antd`, `typescript`, and `@eslint/js` until peer dependencies allow them (closes the #222–#224 class of broken PRs at the source).

## Test plan
- [ ] Confirm `.github/dependabot.yml` validates (GitHub Dependabot config UI / next weekly run).
- [ ] Next Dependabot PR title starts with `[None]`.