### PR TITLE
[Minor] Remove selected buckets from waiver rules

### DIFF
--- a/docs/waivers.md
+++ b/docs/waivers.md
@@ -166,13 +166,20 @@ separately**:
    (Details collapses). Use **Select by axis** (modal with live bucket count)
    to tick values: same axis adds (OR), other axes narrow (AND). **Selected
    only** filters the table to the current selection so you can confirm the
-   rule; with nothing selected it becomes **Show waivers**. **Create
+   rule; with nothing selected it becomes **Show waivers**. **Select unhit** /
+   **Select waived** fill the selection from visible rows. **Create
    waiver…** appends inferred rules to the session draft; the selection clears
-   afterward. Rules with the **same reason** condense axis values (e.g.
-   `x: ["0","1"]`); different reasons stay separate. Reason and Author fields
-   offer autocomplete from the current draft; Author defaults to the last used
-   value after the first create. Edit any rule from the Waivers panel via the
-   pencil icon.
+   afterward. Rules with the **same reason** can condense axis values (e.g.
+   `x: ["0","1"]`) after a **Condense / Keep separate** prompt; different
+   reasons stay separate. Reason and Author fields offer autocomplete from the
+   current draft; Author defaults to the last used value after the first
+   create. Edit any rule from the Waivers panel via the pencil icon.
+7. **Remove from waivers…** (create mode) rewrites the single-coverpoint rules
+   that own the selected waived buckets: remaining coverage is re-inferred
+   with exact cover (same reason/author), empty owners are deleted, and a
+   condense prompt appears when replacements can merge with other same-reason
+   rules. Multi-coverpoint / broad glob owners are left alone — edit or remove
+   those from Manage waivers.
 
 Waived buckets use a distinct violet tint. If a waived bucket still has hits,
 Hit % shows **Waived (hit)** in a stronger rose-violet (Hits/Target stay in

--- a/viewer/src/features/Dashboard/components/RemoveWaiverModal/index.tsx
+++ b/viewer/src/features/Dashboard/components/RemoveWaiverModal/index.tsx
@@ -1,0 +1,331 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Noodle-Bytes. All Rights Reserved
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import {
+    Modal,
+    Typography,
+    List,
+    Tag,
+    Space,
+    Button,
+    Spin,
+    Alert,
+} from "antd";
+import {
+    applyRemoveBucketsResult,
+    mergeWaiverSpecs,
+    removeBucketsFromWaiverRules,
+    wouldCondenseWaiverSpecs,
+    type RemoveBucketsFromWaiversResult,
+    type SelectedBucket,
+} from "@/services/inferWaiverRules";
+import { useWaiverSession } from "@/hooks/useWaiverSession";
+import WaiverAxesList from "../WaiverAxesList";
+
+const COLLAPSED_RULE_COUNT = 3;
+
+type RemoveWaiverModalProps = {
+    open: boolean;
+    onClose: () => void;
+    /** Called after rules are updated (before close). */
+    onRemoved?: () => void;
+    pointPath: string;
+    selectedKeys: number[];
+    allWaivable: SelectedBucket[];
+};
+
+function ruleNumber(index: number): string {
+    return `#${index + 1}`;
+}
+
+export default function RemoveWaiverModal({
+    open,
+    onClose,
+    onRemoved,
+    pointPath,
+    selectedKeys,
+    allWaivable,
+}: RemoveWaiverModalProps) {
+    const waivers = useWaiverSession();
+    const [result, setResult] = useState<RemoveBucketsFromWaiversResult | null>(null);
+    const [computing, setComputing] = useState(false);
+    const [rulesExpanded, setRulesExpanded] = useState(false);
+    const [openAxisRules, setOpenAxisRules] = useState<Set<number>>(() => new Set());
+    const [condensePromptOpen, setCondensePromptOpen] = useState(false);
+
+    useEffect(() => {
+        if (!open) {
+            setResult(null);
+            setComputing(false);
+            setRulesExpanded(false);
+            setOpenAxisRules(new Set());
+            setCondensePromptOpen(false);
+            return;
+        }
+
+        let cancelled = false;
+        setComputing(true);
+        setResult(null);
+        setRulesExpanded(false);
+        setOpenAxisRules(new Set());
+        setCondensePromptOpen(false);
+
+        const handle = window.setTimeout(() => {
+            const diagnostics = waivers.report?.diagnostics ?? [];
+            const next = removeBucketsFromWaiverRules(
+                waivers.file.waivers,
+                diagnostics,
+                pointPath,
+                selectedKeys,
+                allWaivable,
+            );
+            if (!cancelled) {
+                setResult(next);
+                setComputing(false);
+            }
+        }, 0);
+
+        return () => {
+            cancelled = true;
+            window.clearTimeout(handle);
+        };
+    }, [open, selectedKeys, allWaivable, pointPath, waivers.file.waivers, waivers.report]);
+
+    const canSubmit =
+        !computing
+        && result !== null
+        && (result.removedCount > 0 || result.deletedIndexes.length > 0);
+
+    const hiddenRuleCount = Math.max(
+        0,
+        (result?.replacements.length ?? 0) - COLLAPSED_RULE_COUNT,
+    );
+    const visibleReplacements =
+        result === null
+            ? []
+            : rulesExpanded || hiddenRuleCount === 0
+              ? result.replacements
+              : result.replacements.slice(0, COLLAPSED_RULE_COUNT);
+
+    const condensePreview = useMemo(() => {
+        if (!result || result.replacements.length === 0) {
+            return null;
+        }
+        const separateTotal = result.unchanged.length + result.replacements.length;
+        const condensedTotal = mergeWaiverSpecs(
+            result.unchanged,
+            result.replacements,
+        ).length;
+        return {
+            incoming: result.replacements.length,
+            separateTotal,
+            condensedTotal,
+            absorbed: separateTotal - condensedTotal,
+        };
+    }, [result]);
+
+    const finishApply = (condense: boolean) => {
+        if (!result) {
+            return;
+        }
+        const next = applyRemoveBucketsResult(result, condense);
+        waivers.replaceRules(next);
+        setCondensePromptOpen(false);
+        onRemoved?.();
+        onClose();
+    };
+
+    const submit = () => {
+        if (!result || !canSubmit) {
+            return;
+        }
+        if (wouldCondenseWaiverSpecs(result.unchanged, result.replacements)) {
+            setCondensePromptOpen(true);
+            return;
+        }
+        finishApply(false);
+    };
+
+    const summaryParts: string[] = [];
+    if (result) {
+        if (result.removedCount > 0) {
+            summaryParts.push(
+                `Remove ${result.removedCount} waived bucket${result.removedCount === 1 ? "" : "s"}`,
+            );
+        }
+        if (result.rewrittenIndexes.length > 0) {
+            summaryParts.push(
+                `rewrite ${result.rewrittenIndexes.map(ruleNumber).join(", ")}`,
+            );
+        }
+        if (result.deletedIndexes.length > 0) {
+            summaryParts.push(
+                `delete ${result.deletedIndexes.map(ruleNumber).join(", ")}`,
+            );
+        }
+    }
+
+    return (
+        <>
+            <Modal
+                title={`Remove from waivers · ${pointPath}`}
+                open={open}
+                onCancel={onClose}
+                footer={null}
+                destroyOnClose
+            >
+                {computing ? (
+                    <div
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems: "center",
+                            gap: 12,
+                            padding: "24px 0",
+                        }}
+                    >
+                        <Spin />
+                        <Typography.Text type="secondary">
+                            Updating waiver rules…
+                        </Typography.Text>
+                    </div>
+                ) : (
+                    <>
+                        <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
+                            {summaryParts.length > 0
+                                ? `${summaryParts.join("; ")}.`
+                                : "No waived buckets in the selection can be removed."}
+                        </Typography.Paragraph>
+
+                        {result && result.skippedMultiPointCount > 0 && (
+                            <Alert
+                                type="warning"
+                                showIcon
+                                style={{ marginBottom: 12 }}
+                                message={
+                                    `${result.skippedMultiPointCount} selected bucket${
+                                        result.skippedMultiPointCount === 1 ? "" : "s"
+                                    } stay waived — owned by a multi-coverpoint rule. Edit or remove that rule in Manage waivers.`
+                                }
+                            />
+                        )}
+
+                        <Space style={{ width: "100%", justifyContent: "flex-end", marginBottom: 16 }}>
+                            <Button onClick={onClose}>Cancel</Button>
+                            <Button type="primary" danger disabled={!canSubmit} onClick={submit}>
+                                Remove from waivers
+                            </Button>
+                        </Space>
+
+                        {result && result.deletedIndexes.length > 0 && result.replacements.length === 0 && (
+                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                                Selected buckets were the only matches for{" "}
+                                {result.deletedIndexes.map(ruleNumber).join(", ")}; those rules
+                                will be deleted.
+                            </Typography.Text>
+                        )}
+
+                        {result && result.replacements.length > 0 && (
+                            <List
+                                size="small"
+                                header={
+                                    <Typography.Text strong>
+                                        Replacement rules ({result.replacements.length})
+                                    </Typography.Text>
+                                }
+                                dataSource={visibleReplacements}
+                                footer={
+                                    hiddenRuleCount > 0 ? (
+                                        <Button
+                                            type="link"
+                                            size="small"
+                                            style={{ paddingInline: 0 }}
+                                            onClick={() => setRulesExpanded((prev) => !prev)}
+                                        >
+                                            {rulesExpanded
+                                                ? "Show less"
+                                                : `Show more (${hiddenRuleCount} more)`}
+                                        </Button>
+                                    ) : null
+                                }
+                                renderItem={(rule, index) => {
+                                    const axesOpen = openAxisRules.has(index);
+                                    return (
+                                        <List.Item>
+                                            <Space
+                                                direction="vertical"
+                                                size={6}
+                                                style={{ width: "100%" }}
+                                            >
+                                                <Typography.Text strong style={{ fontSize: 12 }}>
+                                                    {rule.point}
+                                                </Typography.Text>
+                                                <Space size={6} wrap>
+                                                    <Tag>{rule.reason}</Tag>
+                                                    {rule.author ? (
+                                                        <Tag>{rule.author}</Tag>
+                                                    ) : null}
+                                                </Space>
+                                                <Button
+                                                    type="link"
+                                                    size="small"
+                                                    style={{ paddingInline: 0, height: "auto" }}
+                                                    onClick={() =>
+                                                        setOpenAxisRules((prev) => {
+                                                            const next = new Set(prev);
+                                                            if (next.has(index)) {
+                                                                next.delete(index);
+                                                            } else {
+                                                                next.add(index);
+                                                            }
+                                                            return next;
+                                                        })
+                                                    }
+                                                >
+                                                    {axesOpen ? "Hide rule" : "Show rule"}
+                                                </Button>
+                                                {axesOpen && <WaiverAxesList axes={rule.axes} />}
+                                            </Space>
+                                        </List.Item>
+                                    );
+                                }}
+                            />
+                        )}
+                    </>
+                )}
+            </Modal>
+            <Modal
+                title="Condense with existing rules?"
+                open={condensePromptOpen}
+                onCancel={() => setCondensePromptOpen(false)}
+                destroyOnClose
+                footer={
+                    <Space style={{ width: "100%", justifyContent: "flex-end" }}>
+                        <Button onClick={() => setCondensePromptOpen(false)}>Cancel</Button>
+                        <Button onClick={() => finishApply(false)}>Keep separate</Button>
+                        <Button type="primary" onClick={() => finishApply(true)}>
+                            Condense
+                        </Button>
+                    </Space>
+                }
+            >
+                <Typography.Paragraph style={{ marginTop: 0 }}>
+                    {condensePreview
+                        ? `These ${condensePreview.incoming} replacement rule${
+                              condensePreview.incoming === 1 ? "" : "s"
+                          } share a reason and compatible axes with rules still in the session. Condensing would store ${condensePreview.condensedTotal} rule${
+                              condensePreview.condensedTotal === 1 ? "" : "s"
+                          } total instead of ${condensePreview.separateTotal}.`
+                        : "These replacement rules can merge with existing session rules that share the same reason and compatible axes."}
+                </Typography.Paragraph>
+                <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+                    Condensing combines axis values into fewer rules. Keep separate leaves every
+                    replacement as its own entry.
+                </Typography.Paragraph>
+            </Modal>
+        </>
+    );
+}

--- a/viewer/src/features/Dashboard/lib/coveragegrid.tsx
+++ b/viewer/src/features/Dashboard/lib/coveragegrid.tsx
@@ -81,6 +81,7 @@ import {
 } from "@/services/inferWaiverRules";
 import { iterPointPaths } from "@/services/matchWaivers";
 import CreateWaiverModal from "../components/CreateWaiverModal";
+import RemoveWaiverModal from "../components/RemoveWaiverModal";
 import SelectByAxisModal from "../components/SelectByAxisModal";
 import { useWaiverSession } from "@/hooks/useWaiverSession";
 import {
@@ -1456,6 +1457,7 @@ export function PointGrid({ node, compare }: PointGridProps) {
     const [axisValueFilters, setAxisValueFilters] = useState<Record<string, string[]>>({});
     const [showSelectedOnly, setShowSelectedOnly] = useState(false);
     const [createWaiverOpen, setCreateWaiverOpen] = useState(false);
+    const [removeWaiverOpen, setRemoveWaiverOpen] = useState(false);
     const [selectByAxisOpen, setSelectByAxisOpen] = useState(false);
     const [selectUnhitBusy, setSelectUnhitBusy] = useState(false);
     const [selectUnhitShowModal, setSelectUnhitShowModal] = useState(false);
@@ -1766,7 +1768,7 @@ export function PointGrid({ node, compare }: PointGridProps) {
         });
     }, [model]);
 
-    // Precompute while in create mode so "Select unhit" is mostly a state swap.
+    // Precompute while in create mode so "Select unhit" / "Select waived" is mostly a state swap.
     const visibleUnhitBucketKeys = useMemo(() => {
         if (!creatingWaivers || compare) {
             return [] as number[];
@@ -1780,6 +1782,39 @@ export function PointGrid({ node, compare }: PointGridProps) {
         }
         return keys;
     }, [creatingWaivers, compare, isLargeMode, largeDataSource, fullDataSource]);
+
+    const visibleWaivedBucketKeys = useMemo(() => {
+        if (!creatingWaivers || compare) {
+            return [] as number[];
+        }
+        const source = isLargeMode ? largeDataSource : fullDataSource;
+        const keys: number[] = [];
+        for (const record of source) {
+            if (record.waived) {
+                keys.push(record.key);
+            }
+        }
+        return keys;
+    }, [creatingWaivers, compare, isLargeMode, largeDataSource, fullDataSource]);
+
+    const selectedWaivedCount = useMemo(() => {
+        if (selectedBucketKeys.length === 0 || !model.hasWaivers) {
+            return 0;
+        }
+        const waivedKeys = new Set<number>();
+        for (let row = 0; row < model.rowCount; row += 1) {
+            if (model.waiverReasons[row] !== undefined) {
+                waivedKeys.add(model.bucketKeys[row]);
+            }
+        }
+        let count = 0;
+        for (const key of selectedBucketKeys) {
+            if (waivedKeys.has(key)) {
+                count += 1;
+            }
+        }
+        return count;
+    }, [selectedBucketKeys, model]);
 
     const selectUnhitVisible = useCallback(() => {
         if (selectUnhitBusy) {
@@ -1810,6 +1845,10 @@ export function PointGrid({ node, compare }: PointGridProps) {
         }, 0);
     }, [selectUnhitBusy, visibleUnhitBucketKeys]);
 
+    const selectWaivedVisible = useCallback(() => {
+        setAxisValueFilters({});
+        setSelectedBucketKeys(visibleWaivedBucketKeys);
+    }, [visibleWaivedBucketKeys]);
     const bucketRowSelection =
         compare || !creatingWaivers
             ? undefined
@@ -2449,6 +2488,13 @@ export function PointGrid({ node, compare }: PointGridProps) {
                 </Button>
                 <Button
                     size="small"
+                    disabled={!model.hasWaivers || visibleWaivedBucketKeys.length === 0}
+                    onClick={selectWaivedVisible}
+                >
+                    Select waived
+                </Button>
+                <Button
+                    size="small"
                     type={axisFilterActive ? "primary" : "default"}
                     title="Build a selection from axis values"
                     onClick={() => setSelectByAxisOpen(true)}
@@ -2466,6 +2512,14 @@ export function PointGrid({ node, compare }: PointGridProps) {
                     onClick={() => setCreateWaiverOpen(true)}
                 >
                     Create waiver…
+                </Button>
+                <Button
+                    size="small"
+                    danger
+                    disabled={selectedWaivedCount === 0}
+                    onClick={() => setRemoveWaiverOpen(true)}
+                >
+                    Remove from waivers…
                 </Button>
                 <Checkbox
                     checked={showSelectedOnly}
@@ -2553,6 +2607,14 @@ export function PointGrid({ node, compare }: PointGridProps) {
                         selectedKeys={selectedBucketKeys}
                         allWaivable={allWaivableBuckets}
                     />
+                    <RemoveWaiverModal
+                        open={removeWaiverOpen}
+                        onClose={() => setRemoveWaiverOpen(false)}
+                        onRemoved={clearBucketSelection}
+                        pointPath={pointPath}
+                        selectedKeys={selectedBucketKeys}
+                        allWaivable={allWaivableBuckets}
+                    />
                     <SelectByAxisModal
                         open={selectByAxisOpen}
                         onClose={() => setSelectByAxisOpen(false)}
@@ -2603,6 +2665,14 @@ export function PointGrid({ node, compare }: PointGridProps) {
                     open={createWaiverOpen}
                     onClose={() => setCreateWaiverOpen(false)}
                     onCreated={clearBucketSelection}
+                    pointPath={pointPath}
+                    selectedKeys={selectedBucketKeys}
+                    allWaivable={allWaivableBuckets}
+                />
+                <RemoveWaiverModal
+                    open={removeWaiverOpen}
+                    onClose={() => setRemoveWaiverOpen(false)}
+                    onRemoved={clearBucketSelection}
                     pointPath={pointPath}
                     selectedKeys={selectedBucketKeys}
                     allWaivable={allWaivableBuckets}

--- a/viewer/src/hooks/useWaiverSession.tsx
+++ b/viewer/src/hooks/useWaiverSession.tsx
@@ -57,6 +57,8 @@ type WaiverSessionValue = {
     restoreRule: (index: number, rule: WaiverSpec) => void;
     updateRule: (index: number, rule: WaiverSpec) => void;
     appendRules: (rules: WaiverSpec[], options?: { condense?: boolean }) => void;
+    /** Replace the entire draft waiver list (e.g. after removing buckets from rules). */
+    replaceRules: (rules: WaiverSpec[]) => void;
     /** Replace a covered rule and the earlier rules that claimed its buckets with one merged rule. */
     mergeCoveredRule: (index: number, reason?: string) => void;
     disableAllProblems: () => void;
@@ -208,6 +210,12 @@ export function WaiverSessionProvider({ children }: PropsWithChildren) {
         }
     }, [file.waivers]);
 
+    const replaceRules = useCallback((rules: WaiverSpec[]) => {
+        setFile({ waivers: rules });
+        setPanelOpen(true);
+        notifySuccess({ message: "Waiver rules updated" });
+    }, []);
+
     const mergeCoveredRule = useCallback((index: number, reason?: string) => {
         if (!report) {
             return;
@@ -326,6 +334,7 @@ export function WaiverSessionProvider({ children }: PropsWithChildren) {
         restoreRule,
         updateRule,
         appendRules,
+        replaceRules,
         mergeCoveredRule,
         disableAllProblems,
         removeDisabled,

--- a/viewer/src/services/inferWaiverRules.ts
+++ b/viewer/src/services/inferWaiverRules.ts
@@ -446,6 +446,162 @@ export function wouldCondenseWaiverSpecs(
     return merged.length < existing.length + incoming.length;
 }
 
+/** Ownership fields needed to surgically unwaive buckets (from apply diagnostics). */
+export type WaiverRuleOwnership = {
+    index: number;
+    rule: WaiverSpec;
+    matchedBucketStarts: number[];
+    coverpointPaths: string[];
+};
+
+export type RemoveBucketsFromWaiversResult = {
+    /** Full list with in-place replacements (no cross-rule condense). */
+    next: WaiverSpec[];
+    /** Rules that were not rewritten or deleted. */
+    unchanged: WaiverSpec[];
+    /** Specs that replaced rewritten rules (empty when a rule was deleted). */
+    replacements: WaiverSpec[];
+    /** Buckets successfully removed from single-coverpoint owners. */
+    removedCount: number;
+    /** Rule indexes that were replaced with one or more inferred specs. */
+    rewrittenIndexes: number[];
+    /** Rule indexes dropped because nothing remained after removal. */
+    deletedIndexes: number[];
+    /** How many selected starts were skipped (multi-coverpoint owners). */
+    skippedMultiPointCount: number;
+    /** Bucket starts that could not be removed. */
+    skippedStarts: number[];
+};
+
+/**
+ * Remove selected waived buckets from the draft by rewriting the rules that
+ * own them. Only single-coverpoint rules are rewritten; multi-coverpoint /
+ * broad glob owners are skipped so other points stay waived.
+ *
+ * Remaining coverage for each rewritten rule is re-inferred with exact cover
+ * (same reason / author / disabled). Callers may then ask whether to condense
+ * `replacements` into `unchanged` via {@link wouldCondenseWaiverSpecs}.
+ */
+export function removeBucketsFromWaiverRules(
+    existing: WaiverSpec[],
+    diagnostics: WaiverRuleOwnership[],
+    pointPath: string,
+    removeStarts: Iterable<number>,
+    allWaivable: SelectedBucket[],
+): RemoveBucketsFromWaiversResult {
+    const removeSet = new Set(removeStarts);
+    const byStart = new Map(allWaivable.map((bucket) => [bucket.start, bucket]));
+    const diagByIndex = new Map(diagnostics.map((row) => [row.index, row]));
+
+    const removeByRule = new Map<number, Set<number>>();
+    const skippedStarts: number[] = [];
+    let skippedMultiPointCount = 0;
+
+    for (const row of diagnostics) {
+        for (const start of row.matchedBucketStarts) {
+            if (!removeSet.has(start)) {
+                continue;
+            }
+            const singlePoint =
+                row.coverpointPaths.length === 1
+                && row.coverpointPaths[0] === pointPath;
+            if (!singlePoint) {
+                if (!skippedStarts.includes(start)) {
+                    skippedStarts.push(start);
+                    skippedMultiPointCount += 1;
+                }
+                continue;
+            }
+            let owned = removeByRule.get(row.index);
+            if (!owned) {
+                owned = new Set();
+                removeByRule.set(row.index, owned);
+            }
+            owned.add(start);
+        }
+    }
+
+    type RewriteAction =
+        | { type: "delete" }
+        | { type: "replace"; specs: WaiverSpec[] };
+
+    const actions = new Map<number, RewriteAction>();
+    const rewrittenIndexes: number[] = [];
+    const deletedIndexes: number[] = [];
+    let removedCount = 0;
+
+    for (const [ruleIndex, starts] of removeByRule) {
+        const row = diagByIndex.get(ruleIndex);
+        const rule = existing[ruleIndex] ?? row?.rule;
+        if (!row || !rule) {
+            continue;
+        }
+        removedCount += starts.size;
+        const remainingStarts = row.matchedBucketStarts.filter(
+            (start) => !starts.has(start),
+        );
+        if (remainingStarts.length === 0) {
+            actions.set(ruleIndex, { type: "delete" });
+            deletedIndexes.push(ruleIndex);
+            continue;
+        }
+        const remainingBuckets = remainingStarts
+            .map((start) => byStart.get(start))
+            .filter((bucket): bucket is SelectedBucket => bucket !== undefined);
+        const inferred = inferWaiverRules(remainingBuckets, pointPath, allWaivable);
+        const specs = inferredRulesToSpecs(
+            inferred,
+            rule.reason,
+            rule.author,
+        ).map((spec) => ({
+            ...spec,
+            disabled: rule.disabled,
+        }));
+        actions.set(ruleIndex, { type: "replace", specs });
+        rewrittenIndexes.push(ruleIndex);
+    }
+
+    const next: WaiverSpec[] = [];
+    const unchanged: WaiverSpec[] = [];
+    const replacements: WaiverSpec[] = [];
+
+    for (let index = 0; index < existing.length; index += 1) {
+        const action = actions.get(index);
+        if (!action) {
+            next.push(existing[index]);
+            unchanged.push(existing[index]);
+            continue;
+        }
+        if (action.type === "delete") {
+            continue;
+        }
+        next.push(...action.specs);
+        replacements.push(...action.specs);
+    }
+
+    return {
+        next,
+        unchanged,
+        replacements,
+        removedCount,
+        rewrittenIndexes,
+        deletedIndexes,
+        skippedMultiPointCount,
+        skippedStarts,
+    };
+}
+
+/** Apply a remove result, optionally condensing replacements into unchanged rules. */
+export function applyRemoveBucketsResult(
+    result: RemoveBucketsFromWaiversResult,
+    condense: boolean,
+): WaiverSpec[] {
+    if (condense && result.replacements.length > 0) {
+        return mergeWaiverSpecs(result.unchanged, result.replacements);
+    }
+    return result.next;
+}
+
 /**
  * Axis-value rule builder: values on the same axis are OR'd (additive);
  * different axes are AND'd (constraining). Empty filters match nothing.

--- a/viewer/src/services/waiverAuthoring.test.ts
+++ b/viewer/src/services/waiverAuthoring.test.ts
@@ -23,6 +23,9 @@ import {
     toggleAxisFilterValue,
     mergeWaiverSpecs,
     wouldCondenseWaiverSpecs,
+    removeBucketsFromWaiverRules,
+    applyRemoveBucketsResult,
+    type WaiverRuleOwnership,
 } from "./inferWaiverRules";
 import { InMemoryReadout } from "./readoutUtils";
 
@@ -482,6 +485,229 @@ describe("mergeWaiverSpecs", () => {
         ];
         expect(wouldCondenseWaiverSpecs([], incoming)).toBe(false);
         expect(mergeWaiverSpecs([], incoming)).toEqual(incoming);
+    });
+});
+
+describe("removeBucketsFromWaiverRules", () => {
+    const all = [
+        { start: 0, axisValues: { kind: "A", size: "1" }, target: 1, hits: 0 },
+        { start: 1, axisValues: { kind: "A", size: "2" }, target: 1, hits: 0 },
+        { start: 2, axisValues: { kind: "B", size: "1" }, target: 1, hits: 0 },
+        { start: 3, axisValues: { kind: "B", size: "2" }, target: 1, hits: 0 },
+    ];
+
+    test("dropping one corner from a rectangular rule re-infers exact remainders", () => {
+        const existing = [
+            {
+                point: "top.point",
+                axes: {},
+                reason: "all",
+                author: "a",
+                disabled: false,
+            },
+        ];
+        const diagnostics: WaiverRuleOwnership[] = [
+            {
+                index: 0,
+                rule: existing[0],
+                matchedBucketStarts: [0, 1, 2, 3],
+                coverpointPaths: ["top.point"],
+            },
+        ];
+        const result = removeBucketsFromWaiverRules(
+            existing,
+            diagnostics,
+            "top.point",
+            [0],
+            all,
+        );
+        expect(result.removedCount).toBe(1);
+        expect(result.deletedIndexes).toEqual([]);
+        expect(result.rewrittenIndexes).toEqual([0]);
+        expect(result.next.every((rule) => rule.reason === "all")).toBe(true);
+
+        const remaining = all.filter((bucket) => bucket.start !== 0);
+        const expected = inferWaiverRules(remaining, "top.point", all);
+        expect(result.replacements).toHaveLength(expected.length);
+        expect(expected.every((rule) => rule.extraCount === 0)).toBe(true);
+        expect(
+            [...new Set(expected.flatMap((rule) => rule.coversStarts))].sort(),
+        ).toEqual([1, 2, 3]);
+        // Replacement axes must not re-cover the removed corner.
+        for (const rule of result.replacements) {
+            const filters: Record<string, string[]> = {};
+            for (const [axis, patterns] of Object.entries(rule.axes)) {
+                filters[axis] = typeof patterns === "string" ? [patterns] : patterns;
+            }
+            const matched = Object.keys(filters).length === 0
+                ? all.map((bucket) => bucket.start)
+                : bucketsMatchingAxisFilters(all, filters);
+            expect(matched.includes(0)).toBe(false);
+        }
+    });
+
+    test("removing every bucket owned by a rule deletes it", () => {
+        const existing = [
+            {
+                point: "top.point",
+                axes: { kind: "A" },
+                reason: "A only",
+                author: "",
+                disabled: false,
+            },
+            {
+                point: "top.point",
+                axes: { kind: "B" },
+                reason: "B only",
+                author: "",
+                disabled: false,
+            },
+        ];
+        const diagnostics: WaiverRuleOwnership[] = [
+            {
+                index: 0,
+                rule: existing[0],
+                matchedBucketStarts: [0, 1],
+                coverpointPaths: ["top.point"],
+            },
+            {
+                index: 1,
+                rule: existing[1],
+                matchedBucketStarts: [2, 3],
+                coverpointPaths: ["top.point"],
+            },
+        ];
+        const result = removeBucketsFromWaiverRules(
+            existing,
+            diagnostics,
+            "top.point",
+            [0, 1],
+            all,
+        );
+        expect(result.removedCount).toBe(2);
+        expect(result.deletedIndexes).toEqual([0]);
+        expect(result.next).toEqual([existing[1]]);
+        expect(result.unchanged).toEqual([existing[1]]);
+        expect(result.replacements).toEqual([]);
+    });
+
+    test("skips multi-coverpoint owners while rewriting single-point rules", () => {
+        const existing = [
+            {
+                point: "top.*",
+                axes: { kind: "A" },
+                reason: "glob",
+                author: "",
+                disabled: false,
+            },
+            {
+                point: "top.point",
+                axes: { kind: "B" },
+                reason: "local",
+                author: "",
+                disabled: false,
+            },
+        ];
+        const diagnostics: WaiverRuleOwnership[] = [
+            {
+                index: 0,
+                rule: existing[0],
+                matchedBucketStarts: [0, 1],
+                coverpointPaths: ["top.point", "top.other"],
+            },
+            {
+                index: 1,
+                rule: existing[1],
+                matchedBucketStarts: [2, 3],
+                coverpointPaths: ["top.point"],
+            },
+        ];
+        const result = removeBucketsFromWaiverRules(
+            existing,
+            diagnostics,
+            "top.point",
+            [0, 2],
+            all,
+        );
+        expect(result.skippedMultiPointCount).toBe(1);
+        expect(result.skippedStarts).toEqual([0]);
+        expect(result.removedCount).toBe(1);
+        expect(result.rewrittenIndexes).toEqual([1]);
+        expect(result.next[0]).toEqual(existing[0]);
+        expect(result.next.slice(1).every((rule) => rule.reason === "local")).toBe(true);
+        const localCovered = inferWaiverRules(
+            [all[3]],
+            "top.point",
+            all,
+        );
+        expect(localCovered.every((rule) => rule.extraCount === 0)).toBe(true);
+        expect(localCovered.flatMap((rule) => rule.coversStarts).sort()).toEqual([3]);
+    });
+
+    test("post-rewrite replacements can condense with unchanged siblings", () => {
+        const existing = [
+            {
+                point: "top.point",
+                axes: { x: "0" },
+                reason: "corner",
+                author: "a",
+                disabled: false,
+            },
+            {
+                point: "top.point",
+                axes: { x: ["1", "2"] },
+                reason: "corner",
+                author: "a",
+                disabled: false,
+            },
+        ];
+        const line = [
+            { start: 0, axisValues: { x: "0" }, target: 1, hits: 0 },
+            { start: 1, axisValues: { x: "1" }, target: 1, hits: 0 },
+            { start: 2, axisValues: { x: "2" }, target: 1, hits: 0 },
+        ];
+        const diagnostics: WaiverRuleOwnership[] = [
+            {
+                index: 0,
+                rule: existing[0],
+                matchedBucketStarts: [0],
+                coverpointPaths: ["top.point"],
+            },
+            {
+                index: 1,
+                rule: existing[1],
+                matchedBucketStarts: [1, 2],
+                coverpointPaths: ["top.point"],
+            },
+        ];
+        // Remove x=2 from the second rule → remaining {x:1}, which can merge with {x:0}.
+        const result = removeBucketsFromWaiverRules(
+            existing,
+            diagnostics,
+            "top.point",
+            [2],
+            line,
+        );
+        expect(result.replacements).toEqual([
+            {
+                point: "top.point",
+                axes: { x: "1" },
+                reason: "corner",
+                author: "a",
+                disabled: false,
+            },
+        ]);
+        expect(wouldCondenseWaiverSpecs(result.unchanged, result.replacements)).toBe(true);
+        expect(applyRemoveBucketsResult(result, true)).toEqual([
+            {
+                point: "top.point",
+                axes: { x: ["0", "1"] },
+                reason: "corner",
+                author: "a",
+                disabled: false,
+            },
+        ]);
+        expect(applyRemoveBucketsResult(result, false)).toEqual(result.next);
     });
 });
 


### PR DESCRIPTION
## Summary
- Add create-mode **Select waived** and **Remove from waivers…** so selected waived buckets can be unwaived surgically.
- Rewrite owning single-coverpoint rules with exact-cover re-inference (delete empty owners; skip multi-coverpoint globs), with the same **Condense / Keep separate** confirmation used when creating.
- Document the flow in `docs/waivers.md` and cover the rewrite helpers with unit tests.

## Test plan
- [ ] Load coverage + waivers, enter **Create waivers**, use **Select waived**, then **Remove from waivers…**
- [ ] Confirm preview lists rewritten/deleted rules; remaining coverage stays exact (no newly waived hit buckets)
- [ ] When replacements share reason/axes with siblings, **Condense** / **Keep separate** both behave correctly
- [ ] Multi-coverpoint / glob owners are skipped with a warning; Manage waivers still edits those rules
- [ ] `npm test -- --run src/services/waiverAuthoring.test.ts` passes